### PR TITLE
ci: build anld push images on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: butlerdotdev/butler-server
+
 permissions:
   contents: read
 
@@ -29,7 +33,6 @@ jobs:
         run: CGO_ENABLED=0 go build -buildvcs=false -o bin/butler-server ./cmd/server
 
   image:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: butler-runners
     permissions:
@@ -50,7 +53,7 @@ jobs:
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -58,10 +61,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/butlerdotdev/butler-server
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            # Latest only on main branch
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix=
+            # SHA for every build (traceability)
+            type=sha,prefix=sha-
+            # PR number for PR builds (e.g., pr-42)
+            type=ref,event=pr,prefix=pr-
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Enable pre-merge testing by building container images on PRs.

Tags pushed:
- :pr-N for pull requests (e.g., :pr-42)
- :sha-xxx for all builds
- :latest only on main branch
