### PR TITLE
fix: resolve Docker Hub rate limiting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ permissions:
 jobs:
   build:
     runs-on: butler-runners
-    container:
-      image: golang:1.24-alpine
     steps:
-      - name: Install git
-        run: apk add --no-cache git
-
       - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Clone butler-api
         run: git clone https://github.com/butlerdotdev/butler-api.git ../butler-api
@@ -59,6 +59,12 @@ jobs:
 
       - name: Clone butler-api
         run: git clone https://github.com/butlerdotdev/butler-api.git ../butler-api
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Summary
- Replace `container: golang:1.24-alpine` in build job with `actions/setup-go@v5` to avoid unauthenticated Docker Hub pulls on self-hosted runners
- Add Docker Hub login step in image job before pulling base images

## Context
Self-hosted `butler-runners` hit Docker Hub unauthenticated pull rate limits (429 Too Many Requests), causing CI failures.