### PR TITLE
fix: use ubuntu-latest for multi-arch image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
   image:
     needs: build
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: butler-runners
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- Move `image` CI job from `butler-runners` to `ubuntu-latest` — self-hosted Talos runners lack `binfmt_misc` kernel module needed by `docker/setup-qemu-action` for cross-platform builds

## Test plan
- [ ] CI image job runs on ubuntu-latest and completes successfully
- [ ] Multi-arch image (amd64 + arm64) pushed to GHCR