### PR TITLE
feat: add ImageSync and Image Factory API endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Clean up runner disk space
+        run: |
+          go clean -cache -testcache 2>/dev/null || true
+          rm -rf /tmp/go-build* 2>/dev/null || true
+          docker system prune -f 2>/dev/null || true
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-server
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.5.0
+	github.com/butlerdotdev/butler-api v0.6.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creack/pty v1.1.9
 	github.com/go-chi/chi/v5 v5.2.0
@@ -79,5 +79,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
-
-replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.mod
+++ b/go.mod
@@ -79,3 +79,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
+
+replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/butlerdotdev/butler-api v0.6.0 h1:rB/eh6pMMGBK5vYsMkRdg+LwWJFZ4/aZvM3CfCjRSH8=
+github.com/butlerdotdev/butler-api v0.6.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/butlerdotdev/butler-api v0.5.0 h1:A3leCabrNM2oX6b+HJfQVBMjleETM6Cims6qkf6IzVs=
-github.com/butlerdotdev/butler-api v0.5.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/internal/api/handlers/images.go
+++ b/internal/api/handlers/images.go
@@ -1,0 +1,501 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/butlerdotdev/butler-server/internal/auth"
+	"github.com/butlerdotdev/butler-server/internal/config"
+	"github.com/butlerdotdev/butler-server/internal/k8s"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var imageSyncGVR = schema.GroupVersionResource{
+	Group:    "butler.butlerlabs.dev",
+	Version:  "v1alpha1",
+	Resource: "imagesyncs",
+}
+
+// ImagesHandler handles image sync and image factory proxy endpoints.
+type ImagesHandler struct {
+	k8sClient *k8s.Client
+	config    *config.Config
+	logger    *slog.Logger
+}
+
+// NewImagesHandler creates a new images handler.
+func NewImagesHandler(k8sClient *k8s.Client, cfg *config.Config, logger *slog.Logger) *ImagesHandler {
+	return &ImagesHandler{
+		k8sClient: k8sClient,
+		config:    cfg,
+		logger:    logger,
+	}
+}
+
+// --- Request/Response Types ---
+
+// CreateImageSyncRequest represents an image sync creation request.
+type CreateImageSyncRequest struct {
+	SchematicID    string `json:"schematicID"`
+	Version        string `json:"version"`
+	Arch           string `json:"arch,omitempty"`
+	ProviderConfig string `json:"providerConfig"` // "namespace/name" format
+	Format         string `json:"format,omitempty"`
+	TransferMode   string `json:"transferMode,omitempty"`
+	DisplayName    string `json:"displayName,omitempty"`
+}
+
+// ImageSyncResponse represents an image sync in API responses.
+type ImageSyncResponse struct {
+	Name             string `json:"name"`
+	Namespace        string `json:"namespace"`
+	Phase            string `json:"phase"`
+	SchematicID      string `json:"schematicID"`
+	Version          string `json:"version"`
+	Arch             string `json:"arch"`
+	ProviderConfig   string `json:"providerConfig"`
+	ProviderImageRef string `json:"providerImageRef,omitempty"`
+	TransferMode     string `json:"transferMode"`
+	Format           string `json:"format"`
+	FailureReason    string `json:"failureReason,omitempty"`
+	FailureMessage   string `json:"failureMessage,omitempty"`
+	CreatedAt        string `json:"createdAt"`
+}
+
+// FactoryCatalogResponse represents the factory catalog proxy response.
+type FactoryCatalogResponse struct {
+	Entries []FactoryCatalogEntry `json:"entries"`
+}
+
+// FactoryCatalogEntry represents a single entry in the factory catalog.
+type FactoryCatalogEntry struct {
+	OS       string   `json:"os"`
+	Versions []string `json:"versions"`
+	Formats  []string `json:"formats"`
+}
+
+// --- Image Sync CRUD ---
+
+// ListImageSyncs handles GET /api/image-syncs.
+// Supports query params: ?provider=name&status=Ready&schematic=abc123
+func (h *ImagesHandler) ListImageSyncs(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	ctx := r.Context()
+
+	providerFilter := r.URL.Query().Get("provider")
+	statusFilter := r.URL.Query().Get("status")
+	schematicFilter := r.URL.Query().Get("schematic")
+
+	// List all ImageSyncs across namespaces
+	imageSyncs, err := h.k8sClient.Dynamic().Resource(imageSyncGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		h.logger.Error("Failed to list ImageSyncs", "error", err)
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to list image syncs: %v", err))
+		return
+	}
+
+	results := make([]ImageSyncResponse, 0, len(imageSyncs.Items))
+	for _, is := range imageSyncs.Items {
+		resp := imageSyncFromUnstructured(&is)
+
+		// Filter by team access for non-admin users
+		if user != nil && !user.IsAdmin() {
+			isNamespace := is.GetNamespace()
+			// Non-admin users can only see ImageSyncs in namespaces they have access to
+			if user.SelectedTeam != "" {
+				teamNS := "team-" + user.SelectedTeam
+				if isNamespace != teamNS && isNamespace != h.config.SystemNamespace {
+					continue
+				}
+			}
+		}
+
+		// Apply query param filters
+		if providerFilter != "" && resp.ProviderConfig != "" {
+			// Match on provider config name (last segment of "namespace/name")
+			parts := strings.Split(resp.ProviderConfig, "/")
+			pcName := parts[len(parts)-1]
+			if pcName != providerFilter && resp.ProviderConfig != providerFilter {
+				continue
+			}
+		}
+		if statusFilter != "" && resp.Phase != statusFilter {
+			continue
+		}
+		if schematicFilter != "" && !strings.HasPrefix(resp.SchematicID, schematicFilter) {
+			continue
+		}
+
+		results = append(results, resp)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"imageSyncs": results})
+}
+
+// CreateImageSync handles POST /api/image-syncs.
+func (h *ImagesHandler) CreateImageSync(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	ctx := r.Context()
+
+	var req CreateImageSyncRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Validate required fields
+	if req.SchematicID == "" {
+		writeError(w, http.StatusBadRequest, "schematicID is required")
+		return
+	}
+	if req.Version == "" {
+		writeError(w, http.StatusBadRequest, "version is required")
+		return
+	}
+	if req.ProviderConfig == "" {
+		writeError(w, http.StatusBadRequest, "providerConfig is required (format: namespace/name)")
+		return
+	}
+
+	// Parse providerConfig into namespace/name
+	parts := strings.SplitN(req.ProviderConfig, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		writeError(w, http.StatusBadRequest, "providerConfig must be in 'namespace/name' format")
+		return
+	}
+	pcNamespace := parts[0]
+	pcName := parts[1]
+
+	// Verify the referenced ProviderConfig exists
+	_, err := h.k8sClient.GetProviderConfig(ctx, pcNamespace, pcName)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("provider config not found: %s/%s", pcNamespace, pcName))
+		return
+	}
+
+	// Authorization: check operate permission if team context is set
+	if user != nil {
+		if user.SelectedTeam != "" {
+			if user.SelectedTeamRole == auth.RoleViewer {
+				writeError(w, http.StatusForbidden, "viewer role cannot create image syncs")
+				return
+			}
+		} else if !user.IsAdmin() {
+			writeError(w, http.StatusForbidden, "image sync creation requires admin role or team context")
+			return
+		}
+	}
+
+	// Set defaults
+	if req.Arch == "" {
+		req.Arch = "amd64"
+	}
+	if req.Format == "" {
+		req.Format = "qcow2"
+	}
+	if req.TransferMode == "" {
+		req.TransferMode = "direct"
+	}
+
+	// Determine the namespace for the ImageSync
+	namespace := h.config.SystemNamespace
+	if user != nil && user.SelectedTeam != "" {
+		namespace = "team-" + user.SelectedTeam
+	}
+
+	// Generate a deterministic name from the spec
+	nameBase := fmt.Sprintf("%s-%s-%s", req.SchematicID[:8], req.Version, pcName)
+	nameBase = strings.ReplaceAll(nameBase, ".", "-")
+	nameBase = strings.ToLower(nameBase)
+	// Truncate to valid K8s name length
+	if len(nameBase) > 63 {
+		nameBase = nameBase[:63]
+	}
+
+	// Build the unstructured ImageSync object
+	spec := map[string]interface{}{
+		"factoryRef": map[string]interface{}{
+			"schematicID": req.SchematicID,
+			"version":     req.Version,
+			"arch":        req.Arch,
+		},
+		"providerConfigRef": map[string]interface{}{
+			"name":      pcName,
+			"namespace": pcNamespace,
+		},
+		"format":       req.Format,
+		"transferMode": req.TransferMode,
+	}
+
+	if req.DisplayName != "" {
+		spec["displayName"] = req.DisplayName
+	}
+
+	imageSync := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "butler.butlerlabs.dev/v1alpha1",
+			"kind":       "ImageSync",
+			"metadata": map[string]interface{}{
+				"name":      nameBase,
+				"namespace": namespace,
+			},
+			"spec": spec,
+		},
+	}
+
+	created, err := h.k8sClient.Dynamic().Resource(imageSyncGVR).Namespace(namespace).Create(
+		ctx, imageSync, metav1.CreateOptions{},
+	)
+	if err != nil {
+		h.logger.Error("Failed to create ImageSync", "error", err, "name", nameBase, "namespace", namespace)
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to create image sync: %v", err))
+		return
+	}
+
+	h.logger.Info("Created ImageSync", "name", nameBase, "namespace", namespace, "schematicID", req.SchematicID)
+	resp := imageSyncFromUnstructured(created)
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+// GetImageSync handles GET /api/image-syncs/{namespace}/{name}.
+func (h *ImagesHandler) GetImageSync(w http.ResponseWriter, r *http.Request) {
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+	ctx := r.Context()
+
+	imageSync, err := h.k8sClient.Dynamic().Resource(imageSyncGVR).Namespace(namespace).Get(
+		ctx, name, metav1.GetOptions{},
+	)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("image sync not found: %v", err))
+		return
+	}
+
+	resp := imageSyncFromUnstructured(imageSync)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// DeleteImageSync handles DELETE /api/image-syncs/{namespace}/{name}.
+func (h *ImagesHandler) DeleteImageSync(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+	ctx := r.Context()
+
+	// Verify the ImageSync exists
+	_, err := h.k8sClient.Dynamic().Resource(imageSyncGVR).Namespace(namespace).Get(
+		ctx, name, metav1.GetOptions{},
+	)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("image sync not found: %v", err))
+		return
+	}
+
+	// Authorization: require admin or operator role
+	if user != nil {
+		if user.SelectedTeam != "" {
+			if user.SelectedTeamRole == auth.RoleViewer {
+				writeError(w, http.StatusForbidden, "viewer role cannot delete image syncs")
+				return
+			}
+		} else if !user.IsAdmin() {
+			writeError(w, http.StatusForbidden, "image sync deletion requires admin role or team context")
+			return
+		}
+	}
+
+	err = h.k8sClient.Dynamic().Resource(imageSyncGVR).Namespace(namespace).Delete(
+		ctx, name, metav1.DeleteOptions{},
+	)
+	if err != nil {
+		h.logger.Error("Failed to delete ImageSync", "error", err, "name", name, "namespace", namespace)
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to delete image sync: %v", err))
+		return
+	}
+
+	h.logger.Info("Deleted ImageSync", "name", name, "namespace", namespace)
+	writeJSON(w, http.StatusOK, map[string]string{"message": "image sync deletion initiated"})
+}
+
+// --- Factory Proxy Endpoints ---
+
+// GetFactoryCatalog handles GET /api/image-factory/catalog.
+// Proxies to the factory's /v1/catalog endpoint.
+func (h *ImagesHandler) GetFactoryCatalog(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	factoryURL, apiKey, err := h.getFactoryConfig(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("image factory not configured: %v", err))
+		return
+	}
+
+	catalogURL := strings.TrimRight(factoryURL, "/") + "/v1/catalog"
+	h.proxyFactoryRequest(w, r, catalogURL, apiKey)
+}
+
+// GetFactorySchematic handles GET /api/image-factory/schematics/{id}.
+// Proxies to the factory's /v1/schematics/{id} endpoint.
+func (h *ImagesHandler) GetFactorySchematic(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := chi.URLParam(r, "id")
+
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "schematic id is required")
+		return
+	}
+
+	factoryURL, apiKey, err := h.getFactoryConfig(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("image factory not configured: %v", err))
+		return
+	}
+
+	schematicURL := strings.TrimRight(factoryURL, "/") + "/v1/schematics/" + id
+	h.proxyFactoryRequest(w, r, schematicURL, apiKey)
+}
+
+// --- Internal Helpers ---
+
+// getFactoryConfig reads the image factory URL and optional API key from the ButlerConfig.
+func (h *ImagesHandler) getFactoryConfig(ctx context.Context) (string, string, error) {
+	bc, err := h.k8sClient.GetButlerConfigTyped(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get ButlerConfig: %w", err)
+	}
+
+	if !bc.IsImageFactoryConfigured() {
+		return "", "", fmt.Errorf("image factory is not configured in ButlerConfig")
+	}
+
+	factoryURL := bc.GetImageFactoryURL()
+
+	// Read API key from credentials secret if configured
+	var apiKey string
+	if bc.Spec.ImageFactory.CredentialsRef != nil {
+		secretNamespace := bc.Spec.ImageFactory.CredentialsRef.Namespace
+		if secretNamespace == "" {
+			secretNamespace = h.config.SystemNamespace
+		}
+		secret, err := h.k8sClient.GetSecret(ctx, secretNamespace, bc.Spec.ImageFactory.CredentialsRef.Name)
+		if err != nil {
+			h.logger.Warn("Failed to read image factory credentials secret",
+				"error", err,
+				"secret", bc.Spec.ImageFactory.CredentialsRef.Name,
+				"namespace", secretNamespace,
+			)
+			// Continue without API key -- the factory may not require auth
+		} else {
+			apiKey = string(secret.Data["apiKey"])
+		}
+	}
+
+	return factoryURL, apiKey, nil
+}
+
+// proxyFactoryRequest proxies an HTTP GET to the factory and forwards the response.
+func (h *ImagesHandler) proxyFactoryRequest(w http.ResponseWriter, r *http.Request, targetURL, apiKey string) {
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, targetURL, nil)
+	if err != nil {
+		h.logger.Error("Failed to create factory proxy request", "error", err, "url", targetURL)
+		writeError(w, http.StatusInternalServerError, "failed to create proxy request")
+		return
+	}
+
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		h.logger.Error("Factory proxy request failed", "error", err, "url", targetURL)
+		writeError(w, http.StatusBadGateway, fmt.Sprintf("failed to reach image factory: %v", err))
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		h.logger.Warn("Factory returned non-200 status",
+			"status", resp.StatusCode,
+			"url", targetURL,
+			"body", string(body),
+		)
+		writeError(w, resp.StatusCode, fmt.Sprintf("image factory error: %s", string(body)))
+		return
+	}
+
+	// Forward the JSON response
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		h.logger.Error("Failed to forward factory response", "error", err)
+	}
+}
+
+// imageSyncFromUnstructured converts an unstructured ImageSync to the response type.
+func imageSyncFromUnstructured(obj *unstructured.Unstructured) ImageSyncResponse {
+	resp := ImageSyncResponse{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		CreatedAt: obj.GetCreationTimestamp().Format(time.RFC3339),
+	}
+
+	// Spec fields
+	resp.SchematicID, _, _ = unstructured.NestedString(obj.Object, "spec", "factoryRef", "schematicID")
+	resp.Version, _, _ = unstructured.NestedString(obj.Object, "spec", "factoryRef", "version")
+	resp.Arch, _, _ = unstructured.NestedString(obj.Object, "spec", "factoryRef", "arch")
+	resp.Format, _, _ = unstructured.NestedString(obj.Object, "spec", "format")
+	resp.TransferMode, _, _ = unstructured.NestedString(obj.Object, "spec", "transferMode")
+
+	// Build providerConfig as "namespace/name"
+	pcName, _, _ := unstructured.NestedString(obj.Object, "spec", "providerConfigRef", "name")
+	pcNamespace, _, _ := unstructured.NestedString(obj.Object, "spec", "providerConfigRef", "namespace")
+	if pcNamespace != "" && pcName != "" {
+		resp.ProviderConfig = pcNamespace + "/" + pcName
+	} else if pcName != "" {
+		resp.ProviderConfig = pcName
+	}
+
+	// Status fields
+	resp.Phase, _, _ = unstructured.NestedString(obj.Object, "status", "phase")
+	resp.ProviderImageRef, _, _ = unstructured.NestedString(obj.Object, "status", "providerImageRef")
+	resp.FailureReason, _, _ = unstructured.NestedString(obj.Object, "status", "failureReason")
+	resp.FailureMessage, _, _ = unstructured.NestedString(obj.Object, "status", "failureMessage")
+
+	// Default phase if empty
+	if resp.Phase == "" {
+		resp.Phase = "Pending"
+	}
+
+	return resp
+}

--- a/internal/api/handlers/images.go
+++ b/internal/api/handlers/images.go
@@ -65,39 +65,11 @@ type CreateImageSyncRequest struct {
 	SchematicID    string `json:"schematicID"`
 	Version        string `json:"version"`
 	Arch           string `json:"arch,omitempty"`
+	Platform       string `json:"platform,omitempty"`
 	ProviderConfig string `json:"providerConfig"` // "namespace/name" format
 	Format         string `json:"format,omitempty"`
 	TransferMode   string `json:"transferMode,omitempty"`
 	DisplayName    string `json:"displayName,omitempty"`
-}
-
-// ImageSyncResponse represents an image sync in API responses.
-type ImageSyncResponse struct {
-	Name             string `json:"name"`
-	Namespace        string `json:"namespace"`
-	Phase            string `json:"phase"`
-	SchematicID      string `json:"schematicID"`
-	Version          string `json:"version"`
-	Arch             string `json:"arch"`
-	ProviderConfig   string `json:"providerConfig"`
-	ProviderImageRef string `json:"providerImageRef,omitempty"`
-	TransferMode     string `json:"transferMode"`
-	Format           string `json:"format"`
-	FailureReason    string `json:"failureReason,omitempty"`
-	FailureMessage   string `json:"failureMessage,omitempty"`
-	CreatedAt        string `json:"createdAt"`
-}
-
-// FactoryCatalogResponse represents the factory catalog proxy response.
-type FactoryCatalogResponse struct {
-	Entries []FactoryCatalogEntry `json:"entries"`
-}
-
-// FactoryCatalogEntry represents a single entry in the factory catalog.
-type FactoryCatalogEntry struct {
-	OS       string   `json:"os"`
-	Versions []string `json:"versions"`
-	Formats  []string `json:"formats"`
 }
 
 // --- Image Sync CRUD ---
@@ -120,14 +92,11 @@ func (h *ImagesHandler) ListImageSyncs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results := make([]ImageSyncResponse, 0, len(imageSyncs.Items))
+	results := make([]map[string]interface{}, 0, len(imageSyncs.Items))
 	for _, is := range imageSyncs.Items {
-		resp := imageSyncFromUnstructured(&is)
-
 		// Filter by team access for non-admin users
 		if user != nil && !user.IsAdmin() {
 			isNamespace := is.GetNamespace()
-			// Non-admin users can only see ImageSyncs in namespaces they have access to
 			if user.SelectedTeam != "" {
 				teamNS := "team-" + user.SelectedTeam
 				if isNamespace != teamNS && isNamespace != h.config.SystemNamespace {
@@ -137,22 +106,26 @@ func (h *ImagesHandler) ListImageSyncs(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Apply query param filters
-		if providerFilter != "" && resp.ProviderConfig != "" {
-			// Match on provider config name (last segment of "namespace/name")
-			parts := strings.Split(resp.ProviderConfig, "/")
-			pcName := parts[len(parts)-1]
-			if pcName != providerFilter && resp.ProviderConfig != providerFilter {
+		if providerFilter != "" {
+			pcName, _, _ := unstructured.NestedString(is.Object, "spec", "providerConfigRef", "name")
+			if pcName != providerFilter {
 				continue
 			}
 		}
-		if statusFilter != "" && resp.Phase != statusFilter {
-			continue
+		if statusFilter != "" {
+			phase, _, _ := unstructured.NestedString(is.Object, "status", "phase")
+			if phase != statusFilter {
+				continue
+			}
 		}
-		if schematicFilter != "" && !strings.HasPrefix(resp.SchematicID, schematicFilter) {
-			continue
+		if schematicFilter != "" {
+			schematicID, _, _ := unstructured.NestedString(is.Object, "spec", "factoryRef", "schematicID")
+			if !strings.HasPrefix(schematicID, schematicFilter) {
+				continue
+			}
 		}
 
-		results = append(results, resp)
+		results = append(results, is.Object)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{"imageSyncs": results})
@@ -216,6 +189,9 @@ func (h *ImagesHandler) CreateImageSync(w http.ResponseWriter, r *http.Request) 
 	if req.Arch == "" {
 		req.Arch = "amd64"
 	}
+	if req.Platform == "" {
+		req.Platform = "nocloud"
+	}
 	if req.Format == "" {
 		req.Format = "qcow2"
 	}
@@ -244,6 +220,7 @@ func (h *ImagesHandler) CreateImageSync(w http.ResponseWriter, r *http.Request) 
 			"schematicID": req.SchematicID,
 			"version":     req.Version,
 			"arch":        req.Arch,
+			"platform":    req.Platform,
 		},
 		"providerConfigRef": map[string]interface{}{
 			"name":      pcName,
@@ -279,8 +256,7 @@ func (h *ImagesHandler) CreateImageSync(w http.ResponseWriter, r *http.Request) 
 	}
 
 	h.logger.Info("Created ImageSync", "name", nameBase, "namespace", namespace, "schematicID", req.SchematicID)
-	resp := imageSyncFromUnstructured(created)
-	writeJSON(w, http.StatusCreated, resp)
+	writeJSON(w, http.StatusCreated, created.Object)
 }
 
 // GetImageSync handles GET /api/image-syncs/{namespace}/{name}.
@@ -297,8 +273,7 @@ func (h *ImagesHandler) GetImageSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := imageSyncFromUnstructured(imageSync)
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusOK, imageSync.Object)
 }
 
 // DeleteImageSync handles DELETE /api/image-syncs/{namespace}/{name}.
@@ -462,40 +437,3 @@ func (h *ImagesHandler) proxyFactoryRequest(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-// imageSyncFromUnstructured converts an unstructured ImageSync to the response type.
-func imageSyncFromUnstructured(obj *unstructured.Unstructured) ImageSyncResponse {
-	resp := ImageSyncResponse{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-		CreatedAt: obj.GetCreationTimestamp().Format(time.RFC3339),
-	}
-
-	// Spec fields
-	resp.SchematicID, _, _ = unstructured.NestedString(obj.Object, "spec", "factoryRef", "schematicID")
-	resp.Version, _, _ = unstructured.NestedString(obj.Object, "spec", "factoryRef", "version")
-	resp.Arch, _, _ = unstructured.NestedString(obj.Object, "spec", "factoryRef", "arch")
-	resp.Format, _, _ = unstructured.NestedString(obj.Object, "spec", "format")
-	resp.TransferMode, _, _ = unstructured.NestedString(obj.Object, "spec", "transferMode")
-
-	// Build providerConfig as "namespace/name"
-	pcName, _, _ := unstructured.NestedString(obj.Object, "spec", "providerConfigRef", "name")
-	pcNamespace, _, _ := unstructured.NestedString(obj.Object, "spec", "providerConfigRef", "namespace")
-	if pcNamespace != "" && pcName != "" {
-		resp.ProviderConfig = pcNamespace + "/" + pcName
-	} else if pcName != "" {
-		resp.ProviderConfig = pcName
-	}
-
-	// Status fields
-	resp.Phase, _, _ = unstructured.NestedString(obj.Object, "status", "phase")
-	resp.ProviderImageRef, _, _ = unstructured.NestedString(obj.Object, "status", "providerImageRef")
-	resp.FailureReason, _, _ = unstructured.NestedString(obj.Object, "status", "failureReason")
-	resp.FailureMessage, _, _ = unstructured.NestedString(obj.Object, "status", "failureMessage")
-
-	// Default phase if empty
-	if resp.Phase == "" {
-		resp.Phase = "Pending"
-	}
-
-	return resp
-}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -153,6 +153,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 	networksHandler := handlers.NewNetworksHandler(cfg.K8sClient, cfg.Config)
 	workspaceHandler := handlers.NewWorkspaceHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "workspaces"))
 	observabilityHandler := handlers.NewObservabilityHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "observability"))
+	imagesHandler := handlers.NewImagesHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "images"))
 
 	// Auth middleware - SECURITY: Now re-validates team membership on every request
 	authMiddleware := auth.SessionMiddleware(auth.SessionMiddlewareConfig{
@@ -293,6 +294,16 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 
 			// Observability config (any authenticated user can read)
 			r.Get("/observability/config", observabilityHandler.GetConfig)
+
+			// Image syncs
+			r.Get("/image-syncs", imagesHandler.ListImageSyncs)
+			r.Post("/image-syncs", imagesHandler.CreateImageSync)
+			r.Get("/image-syncs/{namespace}/{name}", imagesHandler.GetImageSync)
+			r.Delete("/image-syncs/{namespace}/{name}", imagesHandler.DeleteImageSync)
+
+			// Image factory proxy
+			r.Get("/image-factory/catalog", imagesHandler.GetFactoryCatalog)
+			r.Get("/image-factory/schematics/{id}", imagesHandler.GetFactorySchematic)
 
 			// Providers
 			r.Get("/providers", providerHandler.List)


### PR DESCRIPTION
## Summary
- Add REST endpoints for ImageSync CRUD: list, create, get, delete
- Add Image Factory proxy endpoints: catalog and schematic details
- Filter support: provider, schematic, status query parameters

## Context
Part of the Butler Image Sync feature. These endpoints enable the console and CLI to manage ImageSync resources and browse the Image Factory catalog without direct factory access.

## Test plan
- [ ] `go vet ./internal/...` passes
- [ ] GET /api/image-syncs returns list
- [ ] POST /api/image-syncs creates resource
- [ ] GET /api/image-factory/catalog proxies to factory