### PR TITLE
feat: include values in installed addon response

### DIFF
--- a/internal/api/handlers/addons.go
+++ b/internal/api/handlers/addons.go
@@ -88,6 +88,7 @@ type InstalledAddonResponse struct {
 	ManagedBy        string                 `json:"managedBy,omitempty"`
 	Namespace        string                 `json:"namespace,omitempty"`
 	Message          string                 `json:"message,omitempty"`
+	Values           map[string]interface{} `json:"values,omitempty"`
 	HelmRelease      map[string]interface{} `json:"helmRelease,omitempty"`
 	Conditions       []ConditionResponse    `json:"conditions,omitempty"`
 }
@@ -762,6 +763,7 @@ func (h *AddonsHandler) tenantAddonToResponse(ctx context.Context, ta *unstructu
 		addonName = name
 	}
 	version, _, _ := unstructured.NestedString(ta.Object, "spec", "version")
+	values, _, _ := unstructured.NestedMap(ta.Object, "spec", "values")
 
 	phase, _, _ := unstructured.NestedString(ta.Object, "status", "phase")
 	installedVersion, _, _ := unstructured.NestedString(ta.Object, "status", "installedVersion")
@@ -810,6 +812,7 @@ func (h *AddonsHandler) tenantAddonToResponse(ctx context.Context, ta *unstructu
 		ManagedBy:        "butler",
 		Namespace:        namespace,
 		Message:          message,
+		Values:           values,
 		HelmRelease:      helmRelease,
 		Conditions:       conditions,
 	}


### PR DESCRIPTION
## Summary

- Adds `values` field to `InstalledAddonResponse`, populated from `spec.values` on the TenantAddon CRD
- Enables the console to display and edit current addon configuration without a separate API call
- 3-line change: one struct field, one NestedMap read, one field assignment

## Test plan

- [ ] GET /api/clusters/{ns}/{name}/addons returns `values` for addons that have custom values
- [ ] Addons without values return `values: null` (omitempty)
- [ ] GET /api/clusters/{ns}/{name}/addons/{addon} returns values for single addon