### PR TITLE
feat: Phase 2 server endpoints for visibility and CRUD

### DIFF
--- a/internal/api/handlers/addons.go
+++ b/internal/api/handlers/addons.go
@@ -27,6 +27,7 @@ import (
 	"github.com/butlerdotdev/butler-server/internal/k8s"
 
 	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -878,6 +879,14 @@ func (h *AddonsHandler) CreateAddonDefinition(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, "name is required")
 		return
 	}
+	if req.DisplayName == "" {
+		writeError(w, http.StatusBadRequest, "displayName is required")
+		return
+	}
+	if req.Category == "" {
+		writeError(w, http.StatusBadRequest, "category is required")
+		return
+	}
 	if req.ChartRepository == "" || req.ChartName == "" {
 		writeError(w, http.StatusBadRequest, "chartRepository and chartName are required")
 		return
@@ -1051,6 +1060,10 @@ func (h *AddonsHandler) DeleteAddonDefinition(w http.ResponseWriter, r *http.Req
 		r.Context(), name, metav1.DeleteOptions{},
 	)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, fmt.Sprintf("addon definition not found: %s", name))
+			return
+		}
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to delete addon definition: %v", err))
 		return
 	}

--- a/internal/api/handlers/addons.go
+++ b/internal/api/handlers/addons.go
@@ -848,3 +848,212 @@ func (h *AddonsHandler) managementAddonToResponse(ctx context.Context, ma *unstr
 		},
 	}
 }
+
+// CreateAddonDefinitionRequest represents a request to create an addon definition.
+type CreateAddonDefinitionRequest struct {
+	Name             string            `json:"name"`
+	DisplayName      string            `json:"displayName"`
+	Description      string            `json:"description"`
+	Category         string            `json:"category"`
+	Icon             string            `json:"icon,omitempty"`
+	ChartRepository  string            `json:"chartRepository"`
+	ChartName        string            `json:"chartName"`
+	DefaultVersion   string            `json:"defaultVersion"`
+	AvailableVersions []string         `json:"availableVersions,omitempty"`
+	DefaultNamespace string            `json:"defaultNamespace,omitempty"`
+	Platform         bool              `json:"platform"`
+	DependsOn        []string          `json:"dependsOn,omitempty"`
+	Links            map[string]string `json:"links,omitempty"`
+}
+
+// CreateAddonDefinition creates a new AddonDefinition CRD.
+func (h *AddonsHandler) CreateAddonDefinition(w http.ResponseWriter, r *http.Request) {
+	var req CreateAddonDefinitionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if req.ChartRepository == "" || req.ChartName == "" {
+		writeError(w, http.StatusBadRequest, "chartRepository and chartName are required")
+		return
+	}
+
+	chart := map[string]interface{}{
+		"repository":     req.ChartRepository,
+		"name":           req.ChartName,
+		"defaultVersion": req.DefaultVersion,
+	}
+	if len(req.AvailableVersions) > 0 {
+		versions := make([]interface{}, 0, len(req.AvailableVersions))
+		for _, v := range req.AvailableVersions {
+			versions = append(versions, v)
+		}
+		chart["availableVersions"] = versions
+	}
+
+	spec := map[string]interface{}{
+		"displayName": req.DisplayName,
+		"description": req.Description,
+		"category":    req.Category,
+		"chart":       chart,
+		"platform":    req.Platform,
+	}
+	if req.Icon != "" {
+		spec["icon"] = req.Icon
+	}
+	if req.DefaultNamespace != "" {
+		spec["defaults"] = map[string]interface{}{
+			"namespace": req.DefaultNamespace,
+		}
+	}
+	if len(req.DependsOn) > 0 {
+		deps := make([]interface{}, 0, len(req.DependsOn))
+		for _, d := range req.DependsOn {
+			deps = append(deps, d)
+		}
+		spec["dependsOn"] = deps
+	}
+	if len(req.Links) > 0 {
+		links := make(map[string]interface{}, len(req.Links))
+		for k, v := range req.Links {
+			links[k] = v
+		}
+		spec["links"] = links
+	}
+
+	ad := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "butler.butlerlabs.dev/v1alpha1",
+			"kind":       "AddonDefinition",
+			"metadata": map[string]interface{}{
+				"name": req.Name,
+			},
+			"spec": spec,
+		},
+	}
+
+	created, err := h.k8sClient.Dynamic().Resource(k8s.AddonDefinitionGVR).Create(
+		r.Context(), ad, metav1.CreateOptions{},
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to create addon definition: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, h.addonDefinitionToResponse(created))
+}
+
+// UpdateAddonDefinition updates an AddonDefinition's mutable fields.
+func (h *AddonsHandler) UpdateAddonDefinition(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+
+	var req CreateAddonDefinitionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	ad, err := h.k8sClient.GetAddonDefinition(r.Context(), name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("addon definition not found: %v", err))
+		return
+	}
+
+	spec, _, _ := unstructured.NestedMap(ad.Object, "spec")
+	if spec == nil {
+		spec = map[string]interface{}{}
+	}
+
+	if req.DisplayName != "" {
+		spec["displayName"] = req.DisplayName
+	}
+	if req.Description != "" {
+		spec["description"] = req.Description
+	}
+	if req.Category != "" {
+		spec["category"] = req.Category
+	}
+	if req.Icon != "" {
+		spec["icon"] = req.Icon
+	}
+	spec["platform"] = req.Platform
+
+	if req.ChartRepository != "" || req.ChartName != "" || req.DefaultVersion != "" {
+		chart, _ := spec["chart"].(map[string]interface{})
+		if chart == nil {
+			chart = map[string]interface{}{}
+		}
+		if req.ChartRepository != "" {
+			chart["repository"] = req.ChartRepository
+		}
+		if req.ChartName != "" {
+			chart["name"] = req.ChartName
+		}
+		if req.DefaultVersion != "" {
+			chart["defaultVersion"] = req.DefaultVersion
+		}
+		if len(req.AvailableVersions) > 0 {
+			versions := make([]interface{}, 0, len(req.AvailableVersions))
+			for _, v := range req.AvailableVersions {
+				versions = append(versions, v)
+			}
+			chart["availableVersions"] = versions
+		}
+		spec["chart"] = chart
+	}
+
+	if req.DefaultNamespace != "" {
+		spec["defaults"] = map[string]interface{}{
+			"namespace": req.DefaultNamespace,
+		}
+	}
+	if len(req.DependsOn) > 0 {
+		deps := make([]interface{}, 0, len(req.DependsOn))
+		for _, d := range req.DependsOn {
+			deps = append(deps, d)
+		}
+		spec["dependsOn"] = deps
+	}
+	if len(req.Links) > 0 {
+		links := make(map[string]interface{}, len(req.Links))
+		for k, v := range req.Links {
+			links[k] = v
+		}
+		spec["links"] = links
+	}
+
+	if err := unstructured.SetNestedField(ad.Object, spec, "spec"); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to set spec: %v", err))
+		return
+	}
+
+	updated, err := h.k8sClient.Dynamic().Resource(k8s.AddonDefinitionGVR).Update(
+		r.Context(), ad, metav1.UpdateOptions{},
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to update addon definition: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, h.addonDefinitionToResponse(updated))
+}
+
+// DeleteAddonDefinition deletes an AddonDefinition.
+func (h *AddonsHandler) DeleteAddonDefinition(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+
+	err := h.k8sClient.Dynamic().Resource(k8s.AddonDefinitionGVR).Delete(
+		r.Context(), name, metav1.DeleteOptions{},
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to delete addon definition: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"message": "addon definition deleted"})
+}

--- a/internal/api/handlers/clusters.go
+++ b/internal/api/handlers/clusters.go
@@ -19,7 +19,9 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1003,8 +1005,11 @@ func (h *ClusterHandler) ExportYAML(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Deep copy to avoid mutating the cached object.
+	export := cluster.DeepCopy()
+	obj := export.Object
+
 	// Strip server-side fields for a clean export.
-	obj := cluster.Object
 	delete(obj, "status")
 	if meta, ok := obj["metadata"].(map[string]interface{}); ok {
 		delete(meta, "resourceVersion")
@@ -1012,6 +1017,8 @@ func (h *ClusterHandler) ExportYAML(w http.ResponseWriter, r *http.Request) {
 		delete(meta, "creationTimestamp")
 		delete(meta, "generation")
 		delete(meta, "managedFields")
+		delete(meta, "selfLink")
+		delete(meta, "ownerReferences")
 	}
 
 	yamlBytes, err := yaml.Marshal(obj)
@@ -1020,8 +1027,10 @@ func (h *ClusterHandler) ExportYAML(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Sanitize filename to prevent header injection.
+	safeName := sanitizeFilename(name)
 	w.Header().Set("Content-Type", "application/x-yaml")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.yaml", name))
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.yaml"`, safeName))
 	w.WriteHeader(http.StatusOK)
 	w.Write(yamlBytes)
 }
@@ -1047,7 +1056,9 @@ func (h *ClusterHandler) ListMachineRequests(w http.ResponseWriter, r *http.Requ
 
 	items := make([]map[string]interface{}, 0)
 	machines, err := h.k8sClient.ListMachineRequests(r.Context(), namespace, name)
-	if err == nil {
+	if err != nil {
+		slog.Debug("failed to list machine requests (CRD may not exist)", "cluster", name, "error", err)
+	} else {
 		for _, m := range machines.Items {
 			items = append(items, m.Object)
 		}
@@ -1077,11 +1088,20 @@ func (h *ClusterHandler) ListLoadBalancerRequests(w http.ResponseWriter, r *http
 
 	items := make([]map[string]interface{}, 0)
 	lbs, err := h.k8sClient.ListLoadBalancerRequests(r.Context(), namespace, name)
-	if err == nil {
+	if err != nil {
+		slog.Debug("failed to list load balancer requests (CRD may not exist)", "cluster", name, "error", err)
+	} else {
 		for _, lb := range lbs.Items {
 			items = append(items, lb.Object)
 		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{"loadBalancerRequests": items})
+}
+
+// sanitizeFilename strips characters that could cause header injection.
+var safeFilenameRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+
+func sanitizeFilename(name string) string {
+	return safeFilenameRe.ReplaceAllString(name, "_")
 }

--- a/internal/api/handlers/clusters.go
+++ b/internal/api/handlers/clusters.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"sigs.k8s.io/yaml"
+
 	"github.com/butlerdotdev/butler-server/internal/auth"
 	"github.com/butlerdotdev/butler-server/internal/config"
 	"github.com/butlerdotdev/butler-server/internal/k8s"
@@ -980,4 +982,106 @@ func buildComponentResourcesMap(cr *ComponentResourcesRequest) map[string]interf
 		}
 	}
 	return result
+}
+
+// ExportYAML returns a TenantCluster as YAML for export.
+func (h *ClusterHandler) ExportYAML(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	cluster, err := h.k8sClient.GetTenantCluster(r.Context(), namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+
+	if user != nil {
+		if err := h.checkClusterAccess(user, cluster); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+	}
+
+	// Strip server-side fields for a clean export.
+	obj := cluster.Object
+	delete(obj, "status")
+	if meta, ok := obj["metadata"].(map[string]interface{}); ok {
+		delete(meta, "resourceVersion")
+		delete(meta, "uid")
+		delete(meta, "creationTimestamp")
+		delete(meta, "generation")
+		delete(meta, "managedFields")
+	}
+
+	yamlBytes, err := yaml.Marshal(obj)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to marshal YAML: %v", err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-yaml")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.yaml", name))
+	w.WriteHeader(http.StatusOK)
+	w.Write(yamlBytes)
+}
+
+// ListMachineRequests returns MachineRequests for a cluster.
+func (h *ClusterHandler) ListMachineRequests(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	cluster, err := h.k8sClient.GetTenantCluster(r.Context(), namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+
+	if user != nil {
+		if err := h.checkClusterAccess(user, cluster); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+	}
+
+	items := make([]map[string]interface{}, 0)
+	machines, err := h.k8sClient.ListMachineRequests(r.Context(), namespace, name)
+	if err == nil {
+		for _, m := range machines.Items {
+			items = append(items, m.Object)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"machineRequests": items})
+}
+
+// ListLoadBalancerRequests returns LoadBalancerRequests for a cluster.
+func (h *ClusterHandler) ListLoadBalancerRequests(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	cluster, err := h.k8sClient.GetTenantCluster(r.Context(), namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+
+	if user != nil {
+		if err := h.checkClusterAccess(user, cluster); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+	}
+
+	items := make([]map[string]interface{}, 0)
+	lbs, err := h.k8sClient.ListLoadBalancerRequests(r.Context(), namespace, name)
+	if err == nil {
+		for _, lb := range lbs.Items {
+			items = append(items, lb.Object)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"loadBalancerRequests": items})
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -234,6 +234,9 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			r.Get("/clusters/{namespace}/{name}/kubeconfig", clusterHandler.GetKubeconfig)
 			r.Get("/clusters/{namespace}/{name}/nodes", clusterHandler.GetNodes)
 			r.Get("/clusters/{namespace}/{name}/events", clusterHandler.GetEvents)
+			r.Get("/clusters/{namespace}/{name}/export", clusterHandler.ExportYAML)
+			r.Get("/clusters/{namespace}/{name}/machines", clusterHandler.ListMachineRequests)
+			r.Get("/clusters/{namespace}/{name}/load-balancers", clusterHandler.ListLoadBalancerRequests)
 
 			// Cluster addons
 			r.Get("/clusters/{namespace}/{name}/addons", addonsHandler.ListClusterAddons)
@@ -369,6 +372,11 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 					r.Delete("/{name}", identityProviderHandler.Delete)
 					r.Post("/{name}/validate", identityProviderHandler.Validate)
 				})
+
+				// Addon catalog management (admin only)
+				r.Post("/addons/catalog", addonsHandler.CreateAddonDefinition)
+				r.Put("/addons/catalog/{name}", addonsHandler.UpdateAddonDefinition)
+				r.Delete("/addons/catalog/{name}", addonsHandler.DeleteAddonDefinition)
 
 				// Network pools and IP allocations
 				r.Get("/networks", networksHandler.ListNetworkPools)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -84,6 +84,18 @@ var (
 		Version:  "v1alpha1",
 		Resource: "ipallocations",
 	}
+
+	MachineRequestGVR = schema.GroupVersionResource{
+		Group:    "butler.butlerlabs.dev",
+		Version:  "v1alpha1",
+		Resource: "machinerequests",
+	}
+
+	LoadBalancerRequestGVR = schema.GroupVersionResource{
+		Group:    "butler.butlerlabs.dev",
+		Version:  "v1alpha1",
+		Resource: "loadbalancerrequests",
+	}
 )
 
 // Client wraps Kubernetes client functionality.
@@ -274,4 +286,20 @@ func (c *Client) GetTenantAddon(ctx context.Context, namespace, name string) (*u
 // DeleteTenantAddon deletes a TenantAddon.
 func (c *Client) DeleteTenantAddon(ctx context.Context, namespace, name string) error {
 	return c.dynamicClient.Resource(TenantAddonGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+// ListMachineRequests lists MachineRequest resources for a cluster.
+func (c *Client) ListMachineRequests(ctx context.Context, namespace, clusterName string) (*unstructured.UnstructuredList, error) {
+	labelSelector := fmt.Sprintf("butler.butlerlabs.dev/cluster=%s", clusterName)
+	return c.dynamicClient.Resource(MachineRequestGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+}
+
+// ListLoadBalancerRequests lists LoadBalancerRequest resources for a cluster.
+func (c *Client) ListLoadBalancerRequests(ctx context.Context, namespace, clusterName string) (*unstructured.UnstructuredList, error) {
+	labelSelector := fmt.Sprintf("butler.butlerlabs.dev/cluster=%s", clusterName)
+	return c.dynamicClient.Resource(LoadBalancerRequestGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
 }


### PR DESCRIPTION
## Summary

- **Cluster YAML export** — `GET /clusters/{namespace}/{name}/export` strips server-side fields and returns clean portable YAML
- **MachineRequest listing** — `GET /clusters/{namespace}/{name}/machines` lists MachineRequests by cluster label
- **LoadBalancerRequest listing** — `GET /clusters/{namespace}/{name}/load-balancers` lists LoadBalancerRequests by cluster label
- **AddonDefinition CRUD** — `POST/PUT/DELETE /admin/addons/catalog/{name}` for admin addon catalog management

## Test plan

- [ ] Verify `GET /clusters/{ns}/{name}/export` returns valid YAML without status/uid/resourceVersion
- [ ] Verify `GET /clusters/{ns}/{name}/machines` returns MachineRequests with correct label filtering
- [ ] Verify `GET /clusters/{ns}/{name}/load-balancers` returns LoadBalancerRequests
- [ ] Verify `POST /admin/addons/catalog` creates AddonDefinition CRD
- [ ] Verify `PUT /admin/addons/catalog/{name}` updates existing AddonDefinition
- [ ] Verify `DELETE /admin/addons/catalog/{name}` deletes AddonDefinition
- [ ] Verify all endpoints require proper authentication