### PR TITLE
feat: PUT endpoint for TenantCluster spec editing

### DIFF
--- a/internal/api/handlers/clusters.go
+++ b/internal/api/handlers/clusters.go
@@ -543,6 +543,279 @@ func (h *ClusterHandler) Scale(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, patched.Object)
 }
 
+// UpdateRequest represents a cluster spec edit request.
+// Only non-nil fields are applied to the existing spec.
+type UpdateRequest struct {
+	// ResourceVersion is required for optimistic concurrency.
+	ResourceVersion string `json:"resourceVersion"`
+
+	// KubernetesVersion changes the target K8s version. No downgrades.
+	KubernetesVersion *string `json:"kubernetesVersion,omitempty"`
+
+	// ControlPlane edits. Only provided fields are applied.
+	ControlPlane *UpdateControlPlane `json:"controlPlane,omitempty"`
+
+	// Workers edits. Only provided fields are applied.
+	Workers *UpdateWorkers `json:"workers,omitempty"`
+
+	// InfrastructureOverride edits. Admin-only.
+	InfrastructureOverride map[string]interface{} `json:"infrastructureOverride,omitempty"`
+
+	// AcknowledgeDowngrade must be true when reducing CP replicas from 3 to 1.
+	AcknowledgeDowngrade bool `json:"acknowledgeDowngrade,omitempty"`
+}
+
+// UpdateControlPlane holds mutable control plane fields.
+type UpdateControlPlane struct {
+	Replicas  *int32                 `json:"replicas,omitempty"`
+	Resources map[string]interface{} `json:"resources,omitempty"`
+}
+
+// UpdateWorkers holds mutable worker fields.
+type UpdateWorkers struct {
+	Replicas        *int32                 `json:"replicas,omitempty"`
+	MachineTemplate map[string]interface{} `json:"machineTemplate,omitempty"`
+}
+
+// FieldError is a structured validation error for a specific field.
+type FieldError struct {
+	Field   string `json:"field"`
+	Reason  string `json:"reason"`
+	Current string `json:"current,omitempty"`
+}
+
+// Update applies spec edits to a TenantCluster with optimistic concurrency.
+// PUT /api/clusters/{namespace}/{name}
+func (h *ClusterHandler) Update(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	cluster, err := h.k8sClient.GetTenantCluster(r.Context(), namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+
+	if user != nil {
+		if err := h.checkClusterAccess(user, cluster); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+		teamRef, _, _ := unstructured.NestedString(cluster.Object, "spec", "teamRef", "name")
+		if err := h.checkOperatePermission(user, teamRef, "edit"); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+	}
+
+	var req UpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.ResourceVersion == "" {
+		writeError(w, http.StatusBadRequest, "resourceVersion is required for optimistic concurrency")
+		return
+	}
+
+	// Reject edits on clusters that aren't in a stable phase
+	phase, _, _ := unstructured.NestedString(cluster.Object, "status", "phase")
+	if phase == "Failed" || phase == "Deleting" {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("cannot edit cluster in %s phase", phase))
+		return
+	}
+
+	// InfrastructureOverride is admin-only
+	if len(req.InfrastructureOverride) > 0 {
+		if user == nil || !user.IsAdmin() {
+			writeError(w, http.StatusForbidden, "infrastructure overrides require platform admin privileges")
+			return
+		}
+	}
+
+	// Validate and apply each field
+	if errs := h.validateUpdateRequest(cluster, &req); len(errs) > 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{"errors": errs})
+		return
+	}
+
+	h.applyUpdateRequest(cluster, &req)
+
+	// Set resourceVersion for optimistic concurrency
+	cluster.SetResourceVersion(req.ResourceVersion)
+
+	updated, err := h.k8sClient.UpdateTenantCluster(r.Context(), cluster)
+	if err != nil {
+		if strings.Contains(err.Error(), "the object has been modified") ||
+			strings.Contains(err.Error(), "Conflict") {
+			// Re-fetch current state so the client can see what changed
+			current, fetchErr := h.k8sClient.GetTenantCluster(r.Context(), namespace, name)
+			if fetchErr != nil {
+				writeError(w, http.StatusConflict, "cluster was modified by another user")
+				return
+			}
+			writeJSON(w, http.StatusConflict, map[string]interface{}{
+				"error":   "cluster was modified by another user",
+				"current": current.Object,
+			})
+			return
+		}
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to update cluster: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, updated.Object)
+}
+
+// validateUpdateRequest checks all fields in the update request for validity.
+func (h *ClusterHandler) validateUpdateRequest(cluster *unstructured.Unstructured, req *UpdateRequest) []FieldError {
+	var errs []FieldError
+
+	if req.KubernetesVersion != nil {
+		current, _, _ := unstructured.NestedString(cluster.Object, "spec", "kubernetesVersion")
+		if err := validateVersionUpgrade(current, *req.KubernetesVersion); err != nil {
+			errs = append(errs, FieldError{
+				Field:   "spec.kubernetesVersion",
+				Reason:  err.Error(),
+				Current: current,
+			})
+		}
+	}
+
+	if req.ControlPlane != nil && req.ControlPlane.Replicas != nil {
+		replicas := *req.ControlPlane.Replicas
+		if replicas != 1 && replicas != 3 {
+			errs = append(errs, FieldError{
+				Field:  "spec.controlPlane.replicas",
+				Reason: "must be 1 or 3 (odd numbers required for etcd quorum)",
+			})
+		}
+		if replicas == 1 {
+			currentReplicas, _, _ := unstructured.NestedInt64(cluster.Object, "spec", "controlPlane", "replicas")
+			if currentReplicas == 3 && !req.AcknowledgeDowngrade {
+				errs = append(errs, FieldError{
+					Field:   "spec.controlPlane.replicas",
+					Reason:  "reducing from 3 to 1 requires acknowledgeDowngrade: true",
+					Current: "3",
+				})
+			}
+		}
+	}
+
+	if req.Workers != nil {
+		if req.Workers.Replicas != nil {
+			replicas := *req.Workers.Replicas
+			if replicas < 1 || replicas > 100 {
+				errs = append(errs, FieldError{
+					Field:  "spec.workers.replicas",
+					Reason: "must be between 1 and 100",
+				})
+			}
+		}
+		if mt, ok := req.Workers.MachineTemplate["cpu"]; ok {
+			if cpu, ok := toInt64(mt); ok && cpu < 1 {
+				errs = append(errs, FieldError{
+					Field:  "spec.workers.machineTemplate.cpu",
+					Reason: "must be at least 1",
+				})
+			}
+		}
+	}
+
+	return errs
+}
+
+// applyUpdateRequest merges the request fields into the cluster object.
+func (h *ClusterHandler) applyUpdateRequest(cluster *unstructured.Unstructured, req *UpdateRequest) {
+	if req.KubernetesVersion != nil {
+		_ = unstructured.SetNestedField(cluster.Object, *req.KubernetesVersion, "spec", "kubernetesVersion")
+	}
+
+	if req.ControlPlane != nil {
+		if req.ControlPlane.Replicas != nil {
+			_ = unstructured.SetNestedField(cluster.Object, int64(*req.ControlPlane.Replicas), "spec", "controlPlane", "replicas")
+		}
+		if req.ControlPlane.Resources != nil {
+			_ = unstructured.SetNestedField(cluster.Object, req.ControlPlane.Resources, "spec", "controlPlane", "resources")
+		}
+	}
+
+	if req.Workers != nil {
+		if req.Workers.Replicas != nil {
+			_ = unstructured.SetNestedField(cluster.Object, int64(*req.Workers.Replicas), "spec", "workers", "replicas")
+		}
+		if req.Workers.MachineTemplate != nil {
+			existing, _, _ := unstructured.NestedMap(cluster.Object, "spec", "workers", "machineTemplate")
+			if existing == nil {
+				existing = make(map[string]interface{})
+			}
+			for k, v := range req.Workers.MachineTemplate {
+				existing[k] = v
+			}
+			_ = unstructured.SetNestedField(cluster.Object, existing, "spec", "workers", "machineTemplate")
+		}
+	}
+
+	if len(req.InfrastructureOverride) > 0 {
+		_ = unstructured.SetNestedField(cluster.Object, req.InfrastructureOverride, "spec", "infrastructureOverride")
+	}
+}
+
+// validateVersionUpgrade ensures the target version is not a downgrade.
+func validateVersionUpgrade(current, target string) error {
+	if current == "" || target == "" {
+		return nil
+	}
+	currentParts := parseVersion(current)
+	targetParts := parseVersion(target)
+	if currentParts == nil || targetParts == nil {
+		return nil // let the CRD validation handle format issues
+	}
+	if targetParts[0] < currentParts[0] ||
+		(targetParts[0] == currentParts[0] && targetParts[1] < currentParts[1]) ||
+		(targetParts[0] == currentParts[0] && targetParts[1] == currentParts[1] && targetParts[2] < currentParts[2]) {
+		return fmt.Errorf("downgrade from %s to %s is not permitted", current, target)
+	}
+	return nil
+}
+
+// parseVersion extracts major, minor, patch from a "vX.Y.Z" string.
+func parseVersion(v string) []int {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return nil
+	}
+	var result []int
+	for _, p := range parts {
+		n := 0
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return nil
+			}
+			n = n*10 + int(c-'0')
+		}
+		result = append(result, n)
+	}
+	return result
+}
+
+// toInt64 attempts to convert a JSON number to int64.
+// JSON numbers decode as float64 by default.
+func toInt64(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	}
+	return 0, false
+}
+
 // ToggleWorkspaces enables or disables workspaces on a cluster.
 func (h *ClusterHandler) ToggleWorkspaces(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())

--- a/internal/api/handlers/clusters.go
+++ b/internal/api/handlers/clusters.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -622,17 +623,24 @@ func (h *ClusterHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	// Reject edits on clusters that aren't in a stable phase
 	phase, _, _ := unstructured.NestedString(cluster.Object, "status", "phase")
-	if phase == "Failed" || phase == "Deleting" {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("cannot edit cluster in %s phase", phase))
+	stablePhases := map[string]bool{"Ready": true, "Pending": true, "": true}
+	if !stablePhases[phase] {
+		writeError(w, http.StatusConflict, fmt.Sprintf("cluster is in %s phase; wait for it to stabilize", phase))
 		return
 	}
 
-	// InfrastructureOverride is admin-only
+	// InfrastructureOverride is platform-admin-only
 	if len(req.InfrastructureOverride) > 0 {
-		if user == nil || !user.IsAdmin() {
+		if user == nil || !user.IsPlatformAdmin {
 			writeError(w, http.StatusForbidden, "infrastructure overrides require platform admin privileges")
 			return
 		}
+	}
+
+	// No-op guard: if no fields are set, return the current state without writing
+	if req.KubernetesVersion == nil && req.ControlPlane == nil && req.Workers == nil && len(req.InfrastructureOverride) == 0 {
+		writeJSON(w, http.StatusOK, cluster.Object)
+		return
 	}
 
 	// Validate and apply each field
@@ -648,8 +656,7 @@ func (h *ClusterHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	updated, err := h.k8sClient.UpdateTenantCluster(r.Context(), cluster)
 	if err != nil {
-		if strings.Contains(err.Error(), "the object has been modified") ||
-			strings.Contains(err.Error(), "Conflict") {
+		if apierrors.IsConflict(err) {
 			// Re-fetch current state so the client can see what changed
 			current, fetchErr := h.k8sClient.GetTenantCluster(r.Context(), namespace, name)
 			if fetchErr != nil {
@@ -759,7 +766,14 @@ func (h *ClusterHandler) applyUpdateRequest(cluster *unstructured.Unstructured, 
 	}
 
 	if len(req.InfrastructureOverride) > 0 {
-		_ = unstructured.SetNestedField(cluster.Object, req.InfrastructureOverride, "spec", "infrastructureOverride")
+		existing, _, _ := unstructured.NestedMap(cluster.Object, "spec", "infrastructureOverride")
+		if existing == nil {
+			existing = make(map[string]interface{})
+		}
+		for k, v := range req.InfrastructureOverride {
+			existing[k] = v
+		}
+		_ = unstructured.SetNestedField(cluster.Object, existing, "spec", "infrastructureOverride")
 	}
 }
 

--- a/internal/api/handlers/clusters_update_test.go
+++ b/internal/api/handlers/clusters_update_test.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestValidateVersionUpgrade(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		target  string
+		wantErr bool
+	}{
+		{name: "same version", current: "v1.31.0", target: "v1.31.0", wantErr: false},
+		{name: "minor upgrade", current: "v1.31.0", target: "v1.32.0", wantErr: false},
+		{name: "patch upgrade", current: "v1.31.0", target: "v1.31.1", wantErr: false},
+		{name: "major upgrade", current: "v1.31.0", target: "v2.0.0", wantErr: false},
+		{name: "minor downgrade", current: "v1.31.0", target: "v1.30.0", wantErr: true},
+		{name: "patch downgrade", current: "v1.31.2", target: "v1.31.1", wantErr: true},
+		{name: "major downgrade", current: "v2.0.0", target: "v1.31.0", wantErr: true},
+		{name: "empty current", current: "", target: "v1.32.0", wantErr: false},
+		{name: "empty target", current: "v1.31.0", target: "", wantErr: false},
+		{name: "invalid current", current: "invalid", target: "v1.32.0", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVersionUpgrade(tt.current, tt.target)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateVersionUpgrade(%q, %q) error = %v, wantErr %v", tt.current, tt.target, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []int
+	}{
+		{input: "v1.31.0", want: []int{1, 31, 0}},
+		{input: "v2.0.0", want: []int{2, 0, 0}},
+		{input: "1.31.0", want: []int{1, 31, 0}},
+		{input: "invalid", want: nil},
+		{input: "v1.31", want: nil},
+		{input: "v1.31.0-rc1", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseVersion(tt.input)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("parseVersion(%q) = %v, want nil", tt.input, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("parseVersion(%q) = nil, want %v", tt.input, tt.want)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseVersion(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseVersion(%q)[%d] = %d, want %d", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateUpdateRequest(t *testing.T) {
+	h := &ClusterHandler{}
+
+	makeCluster := func(version string, cpReplicas int64) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"kubernetesVersion": version,
+				"controlPlane": map[string]interface{}{
+					"replicas": cpReplicas,
+				},
+				"workers": map[string]interface{}{
+					"replicas": int64(3),
+				},
+			},
+		}}
+		return obj
+	}
+
+	int32Ptr := func(v int32) *int32 { return &v }
+
+	tests := []struct {
+		name       string
+		cluster    *unstructured.Unstructured
+		req        *UpdateRequest
+		wantErrors int
+	}{
+		{
+			name:    "valid version upgrade",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion:   "12345",
+				KubernetesVersion: strPtr("v1.32.0"),
+			},
+			wantErrors: 0,
+		},
+		{
+			name:    "version downgrade rejected",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion:   "12345",
+				KubernetesVersion: strPtr("v1.30.2"),
+			},
+			wantErrors: 1,
+		},
+		{
+			name:    "CP replicas must be odd",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion: "12345",
+				ControlPlane:    &UpdateControlPlane{Replicas: int32Ptr(2)},
+			},
+			wantErrors: 1,
+		},
+		{
+			name:    "CP replicas 0 rejected",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion: "12345",
+				ControlPlane:    &UpdateControlPlane{Replicas: int32Ptr(0)},
+			},
+			wantErrors: 1,
+		},
+		{
+			name:    "CP 3 to 1 without ack rejected",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion: "12345",
+				ControlPlane:    &UpdateControlPlane{Replicas: int32Ptr(1)},
+			},
+			wantErrors: 1,
+		},
+		{
+			name:    "CP 3 to 1 with ack accepted",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion:      "12345",
+				ControlPlane:         &UpdateControlPlane{Replicas: int32Ptr(1)},
+				AcknowledgeDowngrade: true,
+			},
+			wantErrors: 0,
+		},
+		{
+			name:    "negative worker CPU rejected",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion: "12345",
+				Workers: &UpdateWorkers{
+					MachineTemplate: map[string]interface{}{"cpu": float64(-1)},
+				},
+			},
+			wantErrors: 1,
+		},
+		{
+			name:    "valid worker replicas",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion: "12345",
+				Workers:         &UpdateWorkers{Replicas: int32Ptr(5)},
+			},
+			wantErrors: 0,
+		},
+		{
+			name:    "worker replicas 0 rejected",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion: "12345",
+				Workers:         &UpdateWorkers{Replicas: int32Ptr(0)},
+			},
+			wantErrors: 1,
+		},
+		{
+			name:    "worker replicas 101 rejected",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion: "12345",
+				Workers:         &UpdateWorkers{Replicas: int32Ptr(101)},
+			},
+			wantErrors: 1,
+		},
+		{
+			name:    "multiple errors at once",
+			cluster: makeCluster("v1.31.0", 3),
+			req: &UpdateRequest{
+				ResourceVersion:   "12345",
+				KubernetesVersion: strPtr("v1.30.0"),
+				ControlPlane:      &UpdateControlPlane{Replicas: int32Ptr(4)},
+				Workers:           &UpdateWorkers{Replicas: int32Ptr(0)},
+			},
+			wantErrors: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := h.validateUpdateRequest(tt.cluster, tt.req)
+			if len(errs) != tt.wantErrors {
+				t.Errorf("validateUpdateRequest() returned %d errors, want %d: %+v", len(errs), tt.wantErrors, errs)
+			}
+		})
+	}
+}
+
+func TestApplyUpdateRequest(t *testing.T) {
+	h := &ClusterHandler{}
+
+	int32Ptr := func(v int32) *int32 { return &v }
+
+	t.Run("partial update only changes specified fields", func(t *testing.T) {
+		cluster := &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"kubernetesVersion": "v1.31.0",
+				"controlPlane": map[string]interface{}{
+					"replicas": int64(3),
+				},
+				"workers": map[string]interface{}{
+					"replicas": int64(3),
+					"machineTemplate": map[string]interface{}{
+						"cpu":    int64(4),
+						"memory": "16Gi",
+					},
+				},
+			},
+		}}
+
+		req := &UpdateRequest{
+			Workers: &UpdateWorkers{
+				MachineTemplate: map[string]interface{}{"cpu": float64(8)},
+			},
+		}
+
+		h.applyUpdateRequest(cluster, req)
+
+		version, _, _ := unstructured.NestedString(cluster.Object, "spec", "kubernetesVersion")
+		if version != "v1.31.0" {
+			t.Errorf("kubernetesVersion changed unexpectedly: got %q", version)
+		}
+
+		cpReplicas, _, _ := unstructured.NestedInt64(cluster.Object, "spec", "controlPlane", "replicas")
+		if cpReplicas != 3 {
+			t.Errorf("controlPlane.replicas changed unexpectedly: got %d", cpReplicas)
+		}
+
+		workerReplicas, _, _ := unstructured.NestedInt64(cluster.Object, "spec", "workers", "replicas")
+		if workerReplicas != 3 {
+			t.Errorf("workers.replicas changed unexpectedly: got %d", workerReplicas)
+		}
+
+		cpu, _, _ := unstructured.NestedFieldNoCopy(cluster.Object, "spec", "workers", "machineTemplate", "cpu")
+		if cpu != float64(8) {
+			t.Errorf("workers.machineTemplate.cpu = %v, want 8", cpu)
+		}
+
+		mem, _, _ := unstructured.NestedString(cluster.Object, "spec", "workers", "machineTemplate", "memory")
+		if mem != "16Gi" {
+			t.Errorf("workers.machineTemplate.memory changed unexpectedly: got %q", mem)
+		}
+	})
+
+	t.Run("version and CP replicas update", func(t *testing.T) {
+		cluster := &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"kubernetesVersion": "v1.31.0",
+				"controlPlane": map[string]interface{}{
+					"replicas": int64(1),
+				},
+			},
+		}}
+
+		req := &UpdateRequest{
+			KubernetesVersion: strPtr("v1.32.0"),
+			ControlPlane:      &UpdateControlPlane{Replicas: int32Ptr(3)},
+		}
+
+		h.applyUpdateRequest(cluster, req)
+
+		version, _, _ := unstructured.NestedString(cluster.Object, "spec", "kubernetesVersion")
+		if version != "v1.32.0" {
+			t.Errorf("kubernetesVersion = %q, want v1.32.0", version)
+		}
+
+		replicas, _, _ := unstructured.NestedInt64(cluster.Object, "spec", "controlPlane", "replicas")
+		if replicas != 3 {
+			t.Errorf("controlPlane.replicas = %d, want 3", replicas)
+		}
+	})
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -229,6 +229,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			r.Post("/clusters", clusterHandler.Create)
 			r.Get("/clusters/{namespace}/{name}", clusterHandler.Get)
 			r.Delete("/clusters/{namespace}/{name}", clusterHandler.Delete)
+			r.Put("/clusters/{namespace}/{name}", clusterHandler.Update)
 			r.Patch("/clusters/{namespace}/{name}/scale", clusterHandler.Scale)
 			r.Post("/clusters/{namespace}/{name}/settings/workspaces", clusterHandler.ToggleWorkspaces)
 			r.Get("/clusters/{namespace}/{name}/kubeconfig", clusterHandler.GetKubeconfig)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -191,6 +191,12 @@ func (c *Client) PatchTenantCluster(ctx context.Context, namespace, name string,
 	)
 }
 
+// UpdateTenantCluster performs a full update on a TenantCluster.
+// The caller must set metadata.resourceVersion for optimistic concurrency.
+func (c *Client) UpdateTenantCluster(ctx context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	return c.dynamicClient.Resource(TenantClusterGVR).Namespace(obj.GetNamespace()).Update(ctx, obj, metav1.UpdateOptions{})
+}
+
 // ListProviderConfigs lists all ProviderConfig resources.
 func (c *Client) ListProviderConfigs(ctx context.Context, namespace string) (*unstructured.UnstructuredList, error) {
 	if namespace == "" {


### PR DESCRIPTION
## Summary

- Add `PUT /api/clusters/{namespace}/{name}` with optimistic concurrency via resourceVersion
- Partial update semantics: only non-nil fields are applied to existing spec
- Validates version downgrades, CP replica counts (1 or 3 for etcd quorum), worker bounds (1-100)
- Admin-gated `infrastructureOverride` editing
- Returns structured `FieldError` array on validation failure, 409 with current state on conflict

## Test plan

- [x] Unit tests: version parsing, validation (24 cases), partial apply
- [x] `go vet` clean
- [x] E2E on butler-beta: edited e2e-talos worker memory via console, spec persisted correctly