### PR TITLE
feat: add audit log system with emit-don't-store architecture

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-server
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.9.2
+	github.com/butlerdotdev/butler-api v0.9.3
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creack/pty v1.1.9
 	github.com/go-chi/chi/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/butlerdotdev/butler-api v0.9.2 h1:Rx7RU1/5dW17z2Nz7PjquCtzqsmDZ2R4smBUz0bbLEU=
-github.com/butlerdotdev/butler-api v0.9.2/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.9.3 h1:DZ0CuFms2DgCRHxPIHLJz6/Goe2+PtjtEI7bvGiaPio=
+github.com/butlerdotdev/butler-api v0.9.3/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/internal/api/handlers/audit.go
+++ b/internal/api/handlers/audit.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/butlerdotdev/butler-server/internal/audit"
+	"github.com/butlerdotdev/butler-server/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+// AuditHandler handles audit log query endpoints.
+type AuditHandler struct {
+	emitter *audit.Emitter
+}
+
+// NewAuditHandler creates a new audit handler.
+func NewAuditHandler(emitter *audit.Emitter) *AuditHandler {
+	return &AuditHandler{emitter: emitter}
+}
+
+// ListAll returns audit entries across all teams. Platform admin only.
+func (h *AuditHandler) ListAll(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil || !user.IsPlatformAdmin {
+		writeError(w, http.StatusForbidden, "platform admin access required")
+		return
+	}
+
+	opts := parseAuditQuery(r)
+	entries, total := h.emitter.Buffer().Query(opts)
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"entries": entries,
+		"total":   total,
+		"offset":  opts.Offset,
+		"limit":   opts.Limit,
+	})
+}
+
+// ListTeam returns audit entries for a specific team. Team admin only.
+func (h *AuditHandler) ListTeam(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	teamName := chi.URLParam(r, "name")
+
+	if user == nil {
+		writeError(w, http.StatusForbidden, "authentication required")
+		return
+	}
+
+	if !user.IsPlatformAdmin && !user.IsAdminOfTeam(teamName) {
+		writeError(w, http.StatusForbidden, "team admin access required")
+		return
+	}
+
+	opts := parseAuditQuery(r)
+	opts.TeamRef = teamName
+
+	entries, total := h.emitter.Buffer().Query(opts)
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"entries": entries,
+		"total":   total,
+		"offset":  opts.Offset,
+		"limit":   opts.Limit,
+	})
+}
+
+func parseAuditQuery(r *http.Request) audit.QueryOpts {
+	q := r.URL.Query()
+
+	limit := 50
+	if l, err := strconv.Atoi(q.Get("limit")); err == nil && l > 0 && l <= 200 {
+		limit = l
+	}
+
+	offset := 0
+	if o, err := strconv.Atoi(q.Get("offset")); err == nil && o >= 0 {
+		offset = o
+	}
+
+	opts := audit.QueryOpts{
+		User:         q.Get("user"),
+		Action:       q.Get("action"),
+		ResourceType: q.Get("resourceType"),
+		Offset:       offset,
+		Limit:        limit,
+	}
+
+	if s := q.Get("success"); s == "true" {
+		v := true
+		opts.Success = &v
+	} else if s == "false" {
+		v := false
+		opts.Success = &v
+	}
+
+	if from := q.Get("from"); from != "" {
+		if t, err := time.Parse(time.RFC3339, from); err == nil {
+			opts.From = t
+		} else if t, err := time.Parse("2006-01-02", from); err == nil {
+			opts.From = t
+		}
+	}
+
+	if to := q.Get("to"); to != "" {
+		if t, err := time.Parse(time.RFC3339, to); err == nil {
+			opts.To = t
+		} else if t, err := time.Parse("2006-01-02", to); err == nil {
+			opts.To = t.Add(24*time.Hour - time.Nanosecond) // end of day
+		}
+	}
+
+	return opts
+}

--- a/internal/api/handlers/auth_oidc.go
+++ b/internal/api/handlers/auth_oidc.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/butlerdotdev/butler-server/internal/audit"
 	"github.com/butlerdotdev/butler-server/internal/auth"
 	"github.com/butlerdotdev/butler-server/internal/config"
 )
@@ -35,6 +36,7 @@ type AuthHandler struct {
 	stateStore     *auth.StateStore
 	config         *config.Config
 	logger         *slog.Logger
+	auditEmitter   *audit.Emitter
 }
 
 // NewAuthHandler creates a new auth handler.
@@ -45,6 +47,7 @@ func NewAuthHandler(
 	userService *auth.UserService,
 	cfg *config.Config,
 	logger *slog.Logger,
+	auditEmitter *audit.Emitter,
 ) *AuthHandler {
 	return &AuthHandler{
 		oidcProvider:   oidcProvider,
@@ -54,6 +57,7 @@ func NewAuthHandler(
 		stateStore:     auth.NewStateStore(10 * time.Minute),
 		config:         cfg,
 		logger:         logger,
+		auditEmitter:   auditEmitter,
 	}
 }
 
@@ -224,6 +228,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		"teams", len(teams),
 		"isPlatformAdmin", isPlatformAdmin,
 	)
+	audit.RecordLogin(h.auditEmitter, claims.Email, "sso", r.RemoteAddr)
 
 	// Redirect to app
 	redirectURL := "/"
@@ -337,6 +342,7 @@ func (h *AuthHandler) InternalUserLogin(w http.ResponseWriter, r *http.Request) 
 		"teams", len(teams),
 		"isPlatformAdmin", user.IsPlatformAdmin,
 	)
+	audit.RecordLogin(h.auditEmitter, user.Email, "internal", r.RemoteAddr)
 
 	writeJSON(w, http.StatusOK, LoginResponse{
 		User: UserResponse{
@@ -363,16 +369,23 @@ func (h *AuthHandler) LegacyLogin(w http.ResponseWriter, r *http.Request) {
 
 	// Check legacy admin credentials
 	if req.Username != h.config.Auth.AdminUsername || req.Password != h.config.Auth.AdminPassword {
+		audit.RecordLoginFailed(h.auditEmitter, req.Username, "legacy", r.RemoteAddr, "invalid credentials")
 		writeError(w, http.StatusUnauthorized, "Invalid credentials")
 		return
 	}
 
+	audit.RecordLogin(h.auditEmitter, req.Username, "legacy", r.RemoteAddr)
 	h.createLegacyAdminSession(w, r)
 }
 
 // Logout handles user logout.
 // POST /api/auth/logout
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user != nil {
+		audit.RecordLogout(h.auditEmitter, user.Email, r.RemoteAddr)
+	}
+
 	// Clear session cookie
 	http.SetCookie(w, &http.Cookie{
 		Name:     "butler_session",

--- a/internal/api/handlers/config.go
+++ b/internal/api/handlers/config.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"github.com/butlerdotdev/butler-server/internal/audit"
 	"github.com/butlerdotdev/butler-server/internal/config"
 	"github.com/butlerdotdev/butler-server/internal/k8s"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,17 +31,19 @@ import (
 
 // ConfigHandler handles ButlerConfig management API requests.
 type ConfigHandler struct {
-	k8sClient *k8s.Client
-	config    *config.Config
-	logger    *slog.Logger
+	k8sClient    *k8s.Client
+	config       *config.Config
+	logger       *slog.Logger
+	auditEmitter *audit.Emitter
 }
 
 // NewConfigHandler creates a new config handler.
-func NewConfigHandler(k8sClient *k8s.Client, cfg *config.Config, logger *slog.Logger) *ConfigHandler {
+func NewConfigHandler(k8sClient *k8s.Client, cfg *config.Config, logger *slog.Logger, auditEmitter *audit.Emitter) *ConfigHandler {
 	return &ConfigHandler{
-		k8sClient: k8sClient,
-		config:    cfg,
-		logger:    logger,
+		k8sClient:    k8sClient,
+		config:       cfg,
+		logger:       logger,
+		auditEmitter: auditEmitter,
 	}
 }
 
@@ -61,6 +64,7 @@ type ButlerConfigResponse struct {
 
 	// Integrations
 	ImageFactory     *ImageFactoryInfo `json:"imageFactory,omitempty"`
+	Audit            *AuditInfo        `json:"audit,omitempty"`
 	SSHAuthorizedKey string            `json:"sshAuthorizedKey,omitempty"`
 
 	// Read-only status
@@ -132,6 +136,13 @@ type ImageFactoryInfo struct {
 	AutoSync           *bool  `json:"autoSync,omitempty"`
 }
 
+// AuditInfo contains audit log configuration.
+type AuditInfo struct {
+	Enabled    *bool  `json:"enabled,omitempty"`
+	WebhookURL string `json:"webhookURL,omitempty"`
+	BufferSize *int32 `json:"bufferSize,omitempty"`
+}
+
 // ConfigStatusInfo contains read-only platform status.
 type ConfigStatusInfo struct {
 	TeamCount                int32  `json:"teamCount"`
@@ -150,6 +161,7 @@ type UpdateConfigRequest struct {
 	DefaultTeamLimits           *TeamLimitsInfo            `json:"defaultTeamLimits,omitempty"`
 	DefaultControlPlaneResources *CPResourcesInfo          `json:"defaultControlPlaneResources,omitempty"`
 	ImageFactory                *ImageFactoryInfo          `json:"imageFactory,omitempty"`
+	Audit                       *AuditInfo                 `json:"audit,omitempty"`
 	SSHAuthorizedKey            *string                    `json:"sshAuthorizedKey,omitempty"`
 }
 
@@ -206,6 +218,12 @@ func (h *ConfigHandler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("Failed to re-read ButlerConfig", "error", err)
 		writeError(w, http.StatusInternalServerError, "config updated but failed to read back")
 		return
+	}
+
+	// Sync audit emitter settings from updated config
+	if h.auditEmitter != nil {
+		h.auditEmitter.SetEnabled(updated.IsAuditEnabled())
+		h.auditEmitter.SetWebhookURL(updated.GetAuditWebhookURL())
 	}
 
 	resp := h.buildResponse(updated)
@@ -280,6 +298,14 @@ func (h *ConfigHandler) buildResponse(bc *butlerv1alpha1.ButlerConfig) ButlerCon
 		}
 		if cpr.Scheduler != nil {
 			resp.DefaultControlPlaneResources.Scheduler = buildComponentResourcesInfo(cpr.Scheduler)
+		}
+	}
+
+	if bc.Spec.Audit != nil {
+		resp.Audit = &AuditInfo{
+			Enabled:    bc.Spec.Audit.Enabled,
+			WebhookURL: bc.Spec.Audit.WebhookURL,
+			BufferSize: bc.Spec.Audit.BufferSize,
 		}
 	}
 
@@ -421,6 +447,14 @@ func (h *ConfigHandler) applyUpdate(bc *butlerv1alpha1.ButlerConfig, req *Update
 			}
 		}
 		bc.Spec.ImageFactory = ifCfg
+	}
+
+	if req.Audit != nil {
+		bc.Spec.Audit = &butlerv1alpha1.AuditConfig{
+			Enabled:    req.Audit.Enabled,
+			WebhookURL: req.Audit.WebhookURL,
+			BufferSize: req.Audit.BufferSize,
+		}
 	}
 
 	if req.SSHAuthorizedKey != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/butlerdotdev/butler-server/internal/api/handlers"
+	"github.com/butlerdotdev/butler-server/internal/audit"
 	"github.com/butlerdotdev/butler-server/internal/auth"
 	"github.com/butlerdotdev/butler-server/internal/config"
 	"github.com/butlerdotdev/butler-server/internal/k8s"
@@ -126,6 +127,9 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 		}))
 	}
 
+	// Audit emitter
+	auditEmitter := audit.NewEmitter(10000, "", cfg.Logger.With("component", "audit"))
+
 	// Initialize handlers
 	authHandler := handlers.NewAuthHandler(
 		oidcProvider,
@@ -134,6 +138,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 		userService,
 		cfg.Config,
 		cfg.Logger.With("component", "auth"),
+		auditEmitter,
 	)
 	userHandler := handlers.NewUserHandler(
 		userService,
@@ -154,8 +159,9 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 	workspaceHandler := handlers.NewWorkspaceHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "workspaces"))
 	observabilityHandler := handlers.NewObservabilityHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "observability"))
 	imagesHandler := handlers.NewImagesHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "images"))
-	configHandler := handlers.NewConfigHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "config"))
+	configHandler := handlers.NewConfigHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "config"), auditEmitter)
 	stewardHandler := handlers.NewStewardHandler(cfg.K8sClient, cfg.Config)
+	auditHandler := handlers.NewAuditHandler(auditEmitter)
 
 	// Auth middleware - SECURITY: Now re-validates team membership on every request
 	authMiddleware := auth.SessionMiddleware(auth.SessionMiddlewareConfig{
@@ -192,6 +198,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 		// Protected routes (authentication required)
 		r.Group(func(r chi.Router) {
 			r.Use(authMiddleware)
+			r.Use(audit.Middleware(auditEmitter))
 
 			// Auth endpoints
 			r.Post("/auth/logout", authHandler.Logout)
@@ -339,6 +346,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			r.Get("/teams/{name}/clusters", teamHandler.ListClusters)
 			r.Get("/teams/{name}/members", teamHandler.ListMembers)
 			r.Get("/teams/{name}/groups", teamHandler.ListGroupSyncs)
+			r.Get("/teams/{name}/audit", auditHandler.ListTeam)
 
 			// Team provider management (team members can list, team admins can create/delete)
 			r.Get("/teams/{name}/providers", providerHandler.ListTeamProviders)
@@ -401,6 +409,9 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 				// Platform configuration (admin only)
 				r.Get("/config", configHandler.GetConfig)
 				r.Put("/config", configHandler.UpdateConfig)
+
+				// Audit log (admin only)
+				r.Get("/audit", auditHandler.ListAll)
 
 				// Observability management (admin only)
 				r.Put("/observability/config", observabilityHandler.UpdateConfig)

--- a/internal/audit/auth_events.go
+++ b/internal/audit/auth_events.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import "time"
+
+// RecordLogin records a successful login event.
+func RecordLogin(emitter *Emitter, email, provider, sourceIP string) {
+	if emitter == nil {
+		return
+	}
+	emitter.Emit(Event{
+		Timestamp:  time.Now().UTC(),
+		User:       email,
+		Action:     "login",
+		Success:    true,
+		StatusCode: 200,
+		Provider:   provider,
+		SourceIP:   sourceIP,
+	})
+}
+
+// RecordLogout records a logout event.
+func RecordLogout(emitter *Emitter, email, sourceIP string) {
+	if emitter == nil {
+		return
+	}
+	emitter.Emit(Event{
+		Timestamp:  time.Now().UTC(),
+		User:       email,
+		Action:     "logout",
+		Success:    true,
+		StatusCode: 200,
+		SourceIP:   sourceIP,
+	})
+}
+
+// RecordLoginFailed records a failed login attempt.
+func RecordLoginFailed(emitter *Emitter, email, provider, sourceIP, reason string) {
+	if emitter == nil {
+		return
+	}
+	emitter.Emit(Event{
+		Timestamp:    time.Now().UTC(),
+		User:         email,
+		Action:       "login_failed",
+		Success:      false,
+		StatusCode:   401,
+		Provider:     provider,
+		SourceIP:     sourceIP,
+		ErrorMessage: reason,
+	})
+}

--- a/internal/audit/buffer.go
+++ b/internal/audit/buffer.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"strings"
+	"sync"
+)
+
+// RingBuffer is a fixed-capacity circular buffer of audit events.
+// Thread-safe for concurrent Push and Query operations.
+//
+// Query is O(n) on buffer capacity — it scans all entries under a read lock.
+// At the default capacity of 10,000 this is fast. Setting bufferSize to 100K
+// via ButlerConfig means every query scans 100K entries.
+type RingBuffer struct {
+	mu      sync.RWMutex
+	entries []Event
+	head    int
+	count   int
+	cap     int
+}
+
+// NewRingBuffer creates a ring buffer with the given capacity.
+func NewRingBuffer(capacity int) *RingBuffer {
+	if capacity < 100 {
+		capacity = 100
+	}
+	return &RingBuffer{
+		entries: make([]Event, capacity),
+		cap:     capacity,
+	}
+}
+
+// Push adds an event to the buffer, overwriting the oldest if full.
+func (b *RingBuffer) Push(e Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.entries[b.head] = e
+	b.head = (b.head + 1) % b.cap
+	if b.count < b.cap {
+		b.count++
+	}
+}
+
+// Query returns events matching the filter options and the total count of matches.
+// Events are returned in reverse chronological order (newest first).
+func (b *RingBuffer) Query(opts QueryOpts) ([]Event, int) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.count == 0 {
+		return nil, 0
+	}
+
+	// Iterate in reverse chronological order (newest first)
+	var matched []Event
+	total := 0
+
+	for i := 0; i < b.count; i++ {
+		idx := (b.head - 1 - i + b.cap) % b.cap
+		e := b.entries[idx]
+
+		if !matchesFilter(e, opts) {
+			continue
+		}
+
+		total++
+
+		// Skip entries before offset
+		if total <= opts.Offset {
+			continue
+		}
+
+		// Collect up to limit
+		if opts.Limit > 0 && len(matched) >= opts.Limit {
+			continue // keep counting total
+		}
+
+		matched = append(matched, e)
+	}
+
+	return matched, total
+}
+
+func matchesFilter(e Event, opts QueryOpts) bool {
+	if opts.User != "" && !strings.EqualFold(e.User, opts.User) {
+		return false
+	}
+	if opts.Action != "" && e.Action != opts.Action {
+		return false
+	}
+	if opts.ResourceType != "" && !strings.EqualFold(e.ResourceType, opts.ResourceType) {
+		return false
+	}
+	if opts.Success != nil && e.Success != *opts.Success {
+		return false
+	}
+	if opts.TeamRef != "" && e.TeamRef != opts.TeamRef {
+		return false
+	}
+	if !opts.From.IsZero() && e.Timestamp.Before(opts.From) {
+		return false
+	}
+	if !opts.To.IsZero() && e.Timestamp.After(opts.To) {
+		return false
+	}
+	return true
+}

--- a/internal/audit/emitter.go
+++ b/internal/audit/emitter.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Emitter coordinates audit event emission to all configured targets:
+// structured logs (always), in-memory ring buffer (always), and webhook (optional).
+type Emitter struct {
+	buffer     *RingBuffer
+	logger     *slog.Logger
+	webhookURL string
+	httpClient *http.Client
+	enabled    bool
+}
+
+// NewEmitter creates a new audit emitter.
+func NewEmitter(bufferSize int, webhookURL string, logger *slog.Logger) *Emitter {
+	return &Emitter{
+		buffer:     NewRingBuffer(bufferSize),
+		logger:     logger,
+		webhookURL: webhookURL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		enabled:    true,
+	}
+}
+
+// SetEnabled controls whether audit events are recorded.
+func (e *Emitter) SetEnabled(enabled bool) {
+	e.enabled = enabled
+}
+
+// SetWebhookURL updates the webhook URL at runtime.
+func (e *Emitter) SetWebhookURL(url string) {
+	e.webhookURL = url
+}
+
+// Emit records an audit event to all configured targets.
+func (e *Emitter) Emit(event Event) {
+	if !e.enabled {
+		return
+	}
+	// 1. Structured log — always, synchronous
+	e.logger.Info("audit",
+		slog.String("user", event.User),
+		slog.String("action", event.Action),
+		slog.String("resourceType", event.ResourceType),
+		slog.String("resourceName", event.ResourceName),
+		slog.String("resourceNamespace", event.ResourceNamespace),
+		slog.String("teamRef", event.TeamRef),
+		slog.String("httpMethod", event.HTTPMethod),
+		slog.String("path", event.Path),
+		slog.Int("statusCode", event.StatusCode),
+		slog.Bool("success", event.Success),
+		slog.String("sourceIP", event.SourceIP),
+	)
+
+	// 2. Ring buffer — always, synchronous (fast, mutex-protected)
+	e.buffer.Push(event)
+
+	// 3. Webhook — optional, async (fire-and-forget)
+	if e.webhookURL != "" {
+		go e.sendWebhook(event)
+	}
+}
+
+// Buffer returns the ring buffer for query access.
+func (e *Emitter) Buffer() *RingBuffer {
+	return e.buffer
+}
+
+func (e *Emitter) sendWebhook(event Event) {
+	body, err := json.Marshal(event)
+	if err != nil {
+		e.logger.Error("Failed to marshal audit event for webhook", "error", err)
+		return
+	}
+
+	resp, err := e.httpClient.Post(e.webhookURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		e.logger.Error("Failed to send audit webhook", "error", err, "url", e.webhookURL)
+		return
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		e.logger.Warn("Audit webhook returned non-success status",
+			slog.Int("statusCode", resp.StatusCode),
+			slog.String("url", e.webhookURL),
+		)
+	}
+}

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import "time"
+
+// Event represents a single audit log entry.
+type Event struct {
+	Timestamp         time.Time `json:"timestamp"`
+	User              string    `json:"user"`
+	Action            string    `json:"action"`
+	ResourceType      string    `json:"resourceType,omitempty"`
+	ResourceName      string    `json:"resourceName,omitempty"`
+	ResourceNamespace string    `json:"resourceNamespace,omitempty"`
+	TeamRef           string    `json:"teamRef,omitempty"`
+	HTTPMethod        string    `json:"httpMethod,omitempty"`
+	Path              string    `json:"path,omitempty"`
+	StatusCode        int       `json:"statusCode,omitempty"`
+	Success           bool      `json:"success"`
+	RequestSummary    string    `json:"requestSummary,omitempty"`
+	ErrorMessage      string    `json:"errorMessage,omitempty"`
+	SourceIP          string    `json:"sourceIP,omitempty"`
+	Provider          string    `json:"provider,omitempty"`
+}
+
+// QueryOpts defines filter options for querying the audit buffer.
+type QueryOpts struct {
+	User         string
+	Action       string
+	ResourceType string
+	Success      *bool
+	From         time.Time
+	To           time.Time
+	Offset       int
+	Limit        int
+	TeamRef      string
+}

--- a/internal/audit/middleware.go
+++ b/internal/audit/middleware.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/butlerdotdev/butler-server/internal/auth"
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+// Middleware returns a chi middleware that records audit events for mutation requests.
+// Must be wired AFTER SessionMiddleware so user identity is available.
+func Middleware(emitter *Emitter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			method := r.Method
+
+			// Only audit mutations
+			if method != http.MethodPost && method != http.MethodPut &&
+				method != http.MethodPatch && method != http.MethodDelete {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Skip auth endpoints handled explicitly
+			if isAuthPath(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Capture request body (up to 2KB) and restore for downstream
+			var bodySummary string
+			if r.Body != nil && method != http.MethodDelete {
+				bodyBytes, _ := io.ReadAll(io.LimitReader(r.Body, 2048))
+				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+				bodySummary = ScrubRequestBody(bodyBytes)
+			}
+
+			// Wrap response writer to capture status code
+			ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+			start := time.Now()
+			next.ServeHTTP(ww, r)
+
+			// Build audit event after handler completes
+			statusCode := ww.Status()
+			if statusCode == 0 {
+				statusCode = http.StatusOK
+			}
+
+			user := auth.UserFromContext(r.Context())
+			email := "anonymous"
+			teamRef := ""
+			if user != nil {
+				email = user.Email
+				teamRef = user.SelectedTeam
+			}
+
+			event := Event{
+				Timestamp:         start.UTC(),
+				User:              email,
+				Action:            resolveAction(method, r.URL.Path),
+				ResourceType:      resolveResourceType(r.URL.Path),
+				ResourceName:      chi.URLParam(r, "name"),
+				ResourceNamespace: chi.URLParam(r, "namespace"),
+				TeamRef:           teamRef,
+				HTTPMethod:        method,
+				Path:              r.URL.Path,
+				StatusCode:        statusCode,
+				Success:           statusCode >= 200 && statusCode < 400,
+				RequestSummary:    bodySummary,
+				SourceIP:          r.RemoteAddr,
+			}
+
+			// Capture error from response if failure
+			if !event.Success {
+				event.ErrorMessage = http.StatusText(statusCode)
+			}
+
+			emitter.Emit(event)
+		})
+	}
+}
+
+func isAuthPath(path string) bool {
+	return strings.HasPrefix(path, "/api/auth/login") ||
+		strings.HasPrefix(path, "/api/auth/logout") ||
+		strings.HasPrefix(path, "/api/auth/callback") ||
+		strings.HasPrefix(path, "/api/auth/set-password")
+}
+
+// resolveAction maps HTTP method + path to a semantic action.
+func resolveAction(method, path string) string {
+	switch method {
+	case http.MethodPost:
+		return "create"
+	case http.MethodPut:
+		return "update"
+	case http.MethodDelete:
+		return "delete"
+	case http.MethodPatch:
+		if strings.Contains(path, "/scale") {
+			return "scale"
+		}
+		return "update"
+	default:
+		return strings.ToLower(method)
+	}
+}
+
+// resolveResourceType extracts the resource type from the API path.
+func resolveResourceType(path string) string {
+	pathMap := []struct {
+		prefix       string
+		resourceType string
+	}{
+		{"/api/clusters/", "TenantCluster"},
+		{"/api/teams/", "Team"},
+		{"/api/admin/users/", "User"},
+		{"/api/providers/", "ProviderConfig"},
+		{"/api/admin/identity-providers/", "IdentityProvider"},
+		{"/api/admin/networks/", "NetworkPool"},
+		{"/api/management/addons/", "ManagementAddon"},
+		{"/api/image-syncs/", "ImageSync"},
+		{"/api/admin/config", "ButlerConfig"},
+		{"/api/admin/observability/", "Observability"},
+		{"/api/gitops/", "GitOps"},
+		{"/api/admin/addons/catalog", "AddonDefinition"},
+		{"/api/admin/ipallocations/", "IPAllocation"},
+	}
+
+	for _, entry := range pathMap {
+		if strings.HasPrefix(path, entry.prefix) {
+			// Check for sub-resources
+			suffix := path[len(entry.prefix):]
+			if strings.Contains(suffix, "/addons") {
+				return "TenantAddon"
+			}
+			if strings.Contains(suffix, "/workspaces") {
+				return "Workspace"
+			}
+			if strings.Contains(suffix, "/gitops") {
+				return "GitOps"
+			}
+			if strings.Contains(suffix, "/certificates") {
+				return "Certificate"
+			}
+			return entry.resourceType
+		}
+	}
+
+	return "Unknown"
+}

--- a/internal/audit/scrub.go
+++ b/internal/audit/scrub.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+var sensitiveKeys = map[string]bool{
+	"password":       true,
+	"token":          true,
+	"secret":         true,
+	"kubeconfig":     true,
+	"clientsecret":   true,
+	"apikey":         true,
+	"privatekey":     true,
+	"accesskey":      true,
+	"secretaccesskey": true,
+	"serviceaccount": true,
+}
+
+const maxSummaryLength = 1024
+
+// ScrubRequestBody takes raw JSON bytes, redacts sensitive fields,
+// and returns a truncated string summary.
+func ScrubRequestBody(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(body, &data); err != nil {
+		// Not valid JSON — truncate raw body
+		s := string(body)
+		if len(s) > maxSummaryLength {
+			return s[:maxSummaryLength]
+		}
+		return s
+	}
+
+	scrubMap(data)
+
+	result, err := json.Marshal(data)
+	if err != nil {
+		return ""
+	}
+
+	s := string(result)
+	if len(s) > maxSummaryLength {
+		return s[:maxSummaryLength]
+	}
+	return s
+}
+
+func scrubMap(m map[string]interface{}) {
+	for key, val := range m {
+		if sensitiveKeys[strings.ToLower(key)] {
+			m[key] = "[REDACTED]"
+			continue
+		}
+		switch v := val.(type) {
+		case map[string]interface{}:
+			scrubMap(v)
+		case []interface{}:
+			for _, item := range v {
+				if nested, ok := item.(map[string]interface{}); ok {
+					scrubMap(nested)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Implements a complete audit log system following the kube-apiserver emit-don't-store pattern.

### Three emission targets
1. **Structured JSON logs** (always) — every mutation emitted to stdout as structured slog
2. **In-memory ring buffer** (default 10K entries) — queryable via API for console UI
3. **Webhook sink** (optional) — POST events to customer SIEM

### New package: internal/audit/
- event.go — Event struct and QueryOpts
- buffer.go — Thread-safe ring buffer with O(n) query (documented constraint)
- emitter.go — Coordinates all three emission targets
- middleware.go — Chi middleware capturing mutations (POST/PUT/PATCH/DELETE)
- scrub.go — Secret redaction for request body summaries
- auth_events.go — Explicit helpers for login/logout/failed events

### Request body capture
Uses bytes.NewReader replacement pattern to avoid empty body downstream.

### Endpoints
- GET /api/admin/audit — platform admin, all entries
- GET /api/teams/{name}/audit — team admin, team-scoped entries