### PR TITLE
feat: add notification center with per-client team filtering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-github/v60 v60.0.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	golang.org/x/crypto v0.47.0
 	golang.org/x/oauth2 v0.34.0
@@ -40,7 +41,6 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.16.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/internal/api/handlers/config.go
+++ b/internal/api/handlers/config.go
@@ -29,21 +29,28 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// WebhookConfigurable is something that accepts a webhook URL update at runtime.
+type WebhookConfigurable interface {
+	SetWebhookURL(url string)
+}
+
 // ConfigHandler handles ButlerConfig management API requests.
 type ConfigHandler struct {
-	k8sClient    *k8s.Client
-	config       *config.Config
-	logger       *slog.Logger
-	auditEmitter *audit.Emitter
+	k8sClient       *k8s.Client
+	config          *config.Config
+	logger          *slog.Logger
+	auditEmitter    *audit.Emitter
+	notificationHub WebhookConfigurable
 }
 
 // NewConfigHandler creates a new config handler.
-func NewConfigHandler(k8sClient *k8s.Client, cfg *config.Config, logger *slog.Logger, auditEmitter *audit.Emitter) *ConfigHandler {
+func NewConfigHandler(k8sClient *k8s.Client, cfg *config.Config, logger *slog.Logger, auditEmitter *audit.Emitter, notificationHub WebhookConfigurable) *ConfigHandler {
 	return &ConfigHandler{
-		k8sClient:    k8sClient,
-		config:       cfg,
-		logger:       logger,
-		auditEmitter: auditEmitter,
+		k8sClient:       k8sClient,
+		config:          cfg,
+		logger:          logger,
+		auditEmitter:    auditEmitter,
+		notificationHub: notificationHub,
 	}
 }
 
@@ -64,8 +71,9 @@ type ButlerConfigResponse struct {
 
 	// Integrations
 	ImageFactory     *ImageFactoryInfo `json:"imageFactory,omitempty"`
-	Audit            *AuditInfo        `json:"audit,omitempty"`
-	SSHAuthorizedKey string            `json:"sshAuthorizedKey,omitempty"`
+	Audit            *AuditInfo         `json:"audit,omitempty"`
+	Notifications    *NotificationsInfo `json:"notifications,omitempty"`
+	SSHAuthorizedKey string             `json:"sshAuthorizedKey,omitempty"`
 
 	// Read-only status
 	Status *ConfigStatusInfo `json:"status"`
@@ -136,6 +144,11 @@ type ImageFactoryInfo struct {
 	AutoSync           *bool  `json:"autoSync,omitempty"`
 }
 
+// NotificationsInfo contains notification forwarding configuration.
+type NotificationsInfo struct {
+	WebhookURL string `json:"webhookURL,omitempty"`
+}
+
 // AuditInfo contains audit log configuration.
 type AuditInfo struct {
 	Enabled    *bool  `json:"enabled,omitempty"`
@@ -162,6 +175,7 @@ type UpdateConfigRequest struct {
 	DefaultControlPlaneResources *CPResourcesInfo          `json:"defaultControlPlaneResources,omitempty"`
 	ImageFactory                *ImageFactoryInfo          `json:"imageFactory,omitempty"`
 	Audit                       *AuditInfo                 `json:"audit,omitempty"`
+	Notifications               *NotificationsInfo         `json:"notifications,omitempty"`
 	SSHAuthorizedKey            *string                    `json:"sshAuthorizedKey,omitempty"`
 }
 
@@ -224,6 +238,11 @@ func (h *ConfigHandler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 	if h.auditEmitter != nil {
 		h.auditEmitter.SetEnabled(updated.IsAuditEnabled())
 		h.auditEmitter.SetWebhookURL(updated.GetAuditWebhookURL())
+	}
+
+	// Sync notification hub webhook from updated config
+	if h.notificationHub != nil {
+		h.notificationHub.SetWebhookURL(updated.GetNotificationsWebhookURL())
 	}
 
 	resp := h.buildResponse(updated)
@@ -306,6 +325,12 @@ func (h *ConfigHandler) buildResponse(bc *butlerv1alpha1.ButlerConfig) ButlerCon
 			Enabled:    bc.Spec.Audit.Enabled,
 			WebhookURL: bc.Spec.Audit.WebhookURL,
 			BufferSize: bc.Spec.Audit.BufferSize,
+		}
+	}
+
+	if bc.Spec.Notifications != nil {
+		resp.Notifications = &NotificationsInfo{
+			WebhookURL: bc.Spec.Notifications.WebhookURL,
 		}
 	}
 
@@ -454,6 +479,12 @@ func (h *ConfigHandler) applyUpdate(bc *butlerv1alpha1.ButlerConfig, req *Update
 			Enabled:    req.Audit.Enabled,
 			WebhookURL: req.Audit.WebhookURL,
 			BufferSize: req.Audit.BufferSize,
+		}
+	}
+
+	if req.Notifications != nil {
+		bc.Spec.Notifications = &butlerv1alpha1.NotificationsConfig{
+			WebhookURL: req.Notifications.WebhookURL,
 		}
 	}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -129,6 +129,26 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 
 	// Audit emitter
 	auditEmitter := audit.NewEmitter(10000, "", cfg.Logger.With("component", "audit"))
+	auditEmitter.SetHub(wsHub)
+
+	// Wire session resolver for per-client notification filtering
+	wsHub.SetSessionResolver(func(r *http.Request) (*websocket.SessionInfo, error) {
+		cookie, err := r.Cookie("butler_session")
+		if err != nil {
+			return nil, err
+		}
+		session, err := sessionService.ValidateSession(cookie.Value)
+		if err != nil {
+			return nil, err
+		}
+		info := &websocket.SessionInfo{
+			IsPlatformAdmin: session.IsPlatformAdmin,
+		}
+		for _, tm := range session.Teams {
+			info.Teams = append(info.Teams, websocket.TeamInfo{Name: tm.Name})
+		}
+		return info, nil
+	})
 
 	// Initialize handlers
 	authHandler := handlers.NewAuthHandler(
@@ -159,7 +179,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 	workspaceHandler := handlers.NewWorkspaceHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "workspaces"))
 	observabilityHandler := handlers.NewObservabilityHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "observability"))
 	imagesHandler := handlers.NewImagesHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "images"))
-	configHandler := handlers.NewConfigHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "config"), auditEmitter)
+	configHandler := handlers.NewConfigHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "config"), auditEmitter, wsHub)
 	stewardHandler := handlers.NewStewardHandler(cfg.K8sClient, cfg.Config)
 	auditHandler := handlers.NewAuditHandler(auditEmitter)
 

--- a/internal/audit/emitter.go
+++ b/internal/audit/emitter.go
@@ -22,16 +22,24 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	ws "github.com/butlerdotdev/butler-server/internal/websocket"
 )
 
 // Emitter coordinates audit event emission to all configured targets:
 // structured logs (always), in-memory ring buffer (always), and webhook (optional).
+// NotificationBroadcaster is the interface for sending real-time notifications.
+type NotificationBroadcaster interface {
+	BroadcastNotification(ws.NotificationPayload)
+}
+
 type Emitter struct {
 	buffer     *RingBuffer
 	logger     *slog.Logger
 	webhookURL string
 	httpClient *http.Client
 	enabled    bool
+	hub        NotificationBroadcaster
 }
 
 // NewEmitter creates a new audit emitter.
@@ -53,6 +61,11 @@ func (e *Emitter) SetEnabled(enabled bool) {
 // SetWebhookURL updates the webhook URL at runtime.
 func (e *Emitter) SetWebhookURL(url string) {
 	e.webhookURL = url
+}
+
+// SetHub sets the notification broadcaster for real-time push.
+func (e *Emitter) SetHub(hub NotificationBroadcaster) {
+	e.hub = hub
 }
 
 // Emit records an audit event to all configured targets.
@@ -81,6 +94,13 @@ func (e *Emitter) Emit(event Event) {
 	// 3. Webhook — optional, async (fire-and-forget)
 	if e.webhookURL != "" {
 		go e.sendWebhook(event)
+	}
+
+	// 4. Real-time notification — bridge audit events to WebSocket notifications
+	if e.hub != nil {
+		if n := shouldNotify(event); n != nil {
+			e.hub.BroadcastNotification(*n)
+		}
 	}
 }
 

--- a/internal/audit/notifications.go
+++ b/internal/audit/notifications.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"fmt"
+
+	ws "github.com/butlerdotdev/butler-server/internal/websocket"
+)
+
+// shouldNotify determines if an audit event should generate a real-time notification.
+// Returns nil for events that don't warrant notifications.
+func shouldNotify(event Event) *ws.NotificationPayload {
+	// Cluster mutations (create, delete, scale)
+	if event.ResourceType == "TenantCluster" && event.Success {
+		return clusterMutationNotification(event)
+	}
+
+	// Team membership mutations
+	if event.ResourceType == "Team" && event.Path != "" {
+		if containsSubpath(event.Path, "/members") {
+			return teamMemberNotification(event)
+		}
+		if containsSubpath(event.Path, "/groups") {
+			return teamGroupNotification(event)
+		}
+	}
+
+	// Failed login attempts
+	if event.Action == "login_failed" {
+		return &ws.NotificationPayload{
+			Title:    "Failed login attempt",
+			Message:  fmt.Sprintf("From %s (%s)", event.User, event.SourceIP),
+			Severity: "warning",
+			Category: "security",
+		}
+	}
+
+	// User permission changes
+	if event.ResourceType == "User" && (event.Action == "update" || event.Action == "create" || event.Action == "delete") {
+		return &ws.NotificationPayload{
+			Title:    fmt.Sprintf("User %s %sd", event.ResourceName, event.Action),
+			Message:  fmt.Sprintf("By %s", event.User),
+			Severity: "info",
+			Category: "security",
+			ResourceRef: &ws.ResourceRef{
+				Kind: "User",
+				Name: event.ResourceName,
+			},
+		}
+	}
+
+	// Provider failures
+	if event.ResourceType == "ProviderConfig" && !event.Success {
+		return &ws.NotificationPayload{
+			Title:    fmt.Sprintf("Provider %s operation failed", event.ResourceName),
+			Message:  event.ErrorMessage,
+			Severity: "error",
+			Category: "infra",
+			ResourceRef: &ws.ResourceRef{
+				Kind:      "ProviderConfig",
+				Name:      event.ResourceName,
+				Namespace: event.ResourceNamespace,
+			},
+		}
+	}
+
+	// Image sync failures
+	if event.ResourceType == "ImageSync" && !event.Success {
+		return &ws.NotificationPayload{
+			Title:   "Image sync operation failed",
+			Message: event.ErrorMessage,
+			Severity: "error",
+			Category: "infra",
+			ResourceRef: &ws.ResourceRef{
+				Kind: "ImageSync",
+				Name: event.ResourceName,
+			},
+		}
+	}
+
+	return nil
+}
+
+func teamMemberNotification(event Event) *ws.NotificationPayload {
+	team := event.TeamRef
+	if team == "" {
+		team = event.ResourceName
+	}
+
+	switch event.Action {
+	case "create":
+		return &ws.NotificationPayload{
+			Title:    fmt.Sprintf("Member added to %s", team),
+			Message:  fmt.Sprintf("Added by %s", event.User),
+			Severity: "info",
+			Category: "team",
+			ResourceRef: &ws.ResourceRef{
+				Kind: "Team",
+				Name: team,
+				Team: team,
+			},
+		}
+	case "delete":
+		return &ws.NotificationPayload{
+			Title:    fmt.Sprintf("Member removed from %s", team),
+			Message:  fmt.Sprintf("Removed by %s", event.User),
+			Severity: "warning",
+			Category: "team",
+			ResourceRef: &ws.ResourceRef{
+				Kind: "Team",
+				Name: team,
+				Team: team,
+			},
+		}
+	case "update":
+		return &ws.NotificationPayload{
+			Title:    fmt.Sprintf("Role changed in %s", team),
+			Message:  fmt.Sprintf("Changed by %s", event.User),
+			Severity: "info",
+			Category: "team",
+			ResourceRef: &ws.ResourceRef{
+				Kind: "Team",
+				Name: team,
+				Team: team,
+			},
+		}
+	}
+	return nil
+}
+
+func teamGroupNotification(event Event) *ws.NotificationPayload {
+	team := event.TeamRef
+	if team == "" {
+		team = event.ResourceName
+	}
+
+	switch event.Action {
+	case "create":
+		return &ws.NotificationPayload{
+			Title:    fmt.Sprintf("Group sync added to %s", team),
+			Message:  fmt.Sprintf("Added by %s", event.User),
+			Severity: "info",
+			Category: "team",
+			ResourceRef: &ws.ResourceRef{
+				Kind: "Team",
+				Name: team,
+				Team: team,
+			},
+		}
+	case "delete":
+		return &ws.NotificationPayload{
+			Title:    fmt.Sprintf("Group sync removed from %s", team),
+			Message:  fmt.Sprintf("Removed by %s", event.User),
+			Severity: "warning",
+			Category: "team",
+			ResourceRef: &ws.ResourceRef{
+				Kind: "Team",
+				Name: team,
+				Team: team,
+			},
+		}
+	}
+	return nil
+}
+
+func clusterMutationNotification(event Event) *ws.NotificationPayload {
+	ref := &ws.ResourceRef{
+		Kind:      "TenantCluster",
+		Name:      event.ResourceName,
+		Namespace: event.ResourceNamespace,
+		Team:      event.TeamRef,
+	}
+
+	switch event.Action {
+	case "create":
+		return &ws.NotificationPayload{
+			Title:       fmt.Sprintf("Cluster %s created", event.ResourceName),
+			Message:     fmt.Sprintf("Created by %s", event.User),
+			Severity:    "info",
+			Category:    "cluster",
+			ResourceRef: ref,
+		}
+	case "delete":
+		return &ws.NotificationPayload{
+			Title:       fmt.Sprintf("Cluster %s deletion initiated", event.ResourceName),
+			Message:     fmt.Sprintf("Deleted by %s", event.User),
+			Severity:    "warning",
+			Category:    "cluster",
+			ResourceRef: ref,
+		}
+	case "scale":
+		return &ws.NotificationPayload{
+			Title:       fmt.Sprintf("Cluster %s scaled", event.ResourceName),
+			Message:     fmt.Sprintf("Scaled by %s", event.User),
+			Severity:    "info",
+			Category:    "cluster",
+			ResourceRef: ref,
+		}
+	case "update":
+		return &ws.NotificationPayload{
+			Title:       fmt.Sprintf("Cluster %s updated", event.ResourceName),
+			Message:     fmt.Sprintf("Updated by %s", event.User),
+			Severity:    "info",
+			Category:    "cluster",
+			ResourceRef: ref,
+		}
+	}
+	return nil
+}
+
+func containsSubpath(path, subpath string) bool {
+	return len(path) > 0 && len(subpath) > 0 && contains(path, subpath)
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/websocket/hub.go
+++ b/internal/websocket/hub.go
@@ -17,8 +17,10 @@ limitations under the License.
 package websocket
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -27,8 +29,10 @@ import (
 	"github.com/butlerdotdev/butler-server/internal/k8s"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -49,6 +53,7 @@ const (
 	MessageTypePing          MessageType = "ping"
 	MessageTypePong          MessageType = "pong"
 	MessageTypeError         MessageType = "error"
+	MessageTypeNotification  MessageType = "notification"
 )
 
 // Message represents a WebSocket message.
@@ -68,10 +73,46 @@ type ClusterDeletePayload struct {
 	Namespace string `json:"namespace"`
 }
 
+// NotificationPayload is sent for real-time notifications.
+type NotificationPayload struct {
+	ID          string       `json:"id"`
+	Title       string       `json:"title"`
+	Message     string       `json:"message"`
+	Severity    string       `json:"severity"`
+	Category    string       `json:"category"`
+	Timestamp   time.Time    `json:"timestamp"`
+	ResourceRef *ResourceRef `json:"resourceRef,omitempty"`
+}
+
+// ResourceRef identifies the resource a notification relates to.
+type ResourceRef struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Team      string `json:"team,omitempty"`
+}
+
+// SessionInfo contains the user identity resolved from a WebSocket connection.
+type SessionInfo struct {
+	IsPlatformAdmin bool
+	Teams           []TeamInfo
+}
+
+// TeamInfo contains team membership data.
+type TeamInfo struct {
+	Name string
+}
+
+// SessionResolverFunc resolves user session from an HTTP request.
+type SessionResolverFunc func(r *http.Request) (*SessionInfo, error)
+
 // Hub manages WebSocket connections and cluster watches.
 type Hub struct {
-	k8sClient *k8s.Client
-	log       *slog.Logger
+	k8sClient       *k8s.Client
+	log             *slog.Logger
+	sessionResolver SessionResolverFunc
+	webhookURL      string
+	httpClient      *http.Client
 
 	clients    map[*Client]bool
 	register   chan *Client
@@ -83,9 +124,11 @@ type Hub struct {
 
 // Client represents a WebSocket client connection.
 type Client struct {
-	hub  *Hub
-	conn *websocket.Conn
-	send chan Message
+	hub             *Hub
+	conn            *websocket.Conn
+	send            chan Message
+	teams           []string
+	isPlatformAdmin bool
 }
 
 // NewHub creates a new WebSocket hub.
@@ -93,11 +136,22 @@ func NewHub(k8sClient *k8s.Client, log *slog.Logger) *Hub {
 	return &Hub{
 		k8sClient:  k8sClient,
 		log:        log,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
 		clients:    make(map[*Client]bool),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
 		broadcast:  make(chan Message, 256),
 	}
+}
+
+// SetSessionResolver sets the function used to resolve user sessions from WebSocket upgrade requests.
+func (h *Hub) SetSessionResolver(resolver SessionResolverFunc) {
+	h.sessionResolver = resolver
+}
+
+// SetWebhookURL sets the URL for forwarding notifications to external systems.
+func (h *Hub) SetWebhookURL(url string) {
+	h.webhookURL = url
 }
 
 // Run starts the hub's main loop.
@@ -136,7 +190,79 @@ func (h *Hub) Run() {
 	}
 }
 
+// BroadcastNotification sends a notification to clients that have access to the relevant team.
+// Platform admins receive all notifications. Non-admins only receive notifications
+// where resourceRef.team matches one of their teams. Team-less notifications
+// (e.g., security events) are only sent to platform admins.
+func (h *Hub) BroadcastNotification(n NotificationPayload) {
+	if n.ID == "" {
+		n.ID = uuid.New().String()
+	}
+	if n.Timestamp.IsZero() {
+		n.Timestamp = time.Now()
+	}
+
+	msg := Message{Type: MessageTypeNotification, Payload: n}
+
+	h.mu.RLock()
+	for client := range h.clients {
+		if !clientCanReceive(client, n) {
+			continue
+		}
+		select {
+		case client.send <- msg:
+		default:
+			// Client buffer full, skip
+		}
+	}
+	h.mu.RUnlock()
+
+	// Forward to external webhook if configured
+	if h.webhookURL != "" {
+		go h.sendNotificationWebhook(n)
+	}
+}
+
+func (h *Hub) sendNotificationWebhook(n NotificationPayload) {
+	body, err := json.Marshal(n)
+	if err != nil {
+		h.log.Error("Failed to marshal notification for webhook", "error", err)
+		return
+	}
+
+	resp, err := h.httpClient.Post(h.webhookURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		h.log.Error("Failed to send notification webhook", "error", err, "url", h.webhookURL)
+		return
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		h.log.Warn("Notification webhook returned non-success status",
+			slog.Int("statusCode", resp.StatusCode),
+			slog.String("url", h.webhookURL),
+		)
+	}
+}
+
+func clientCanReceive(c *Client, n NotificationPayload) bool {
+	if c.isPlatformAdmin {
+		return true
+	}
+	if n.ResourceRef == nil || n.ResourceRef.Team == "" {
+		return false
+	}
+	for _, team := range c.teams {
+		if team == n.ResourceRef.Team {
+			return true
+		}
+	}
+	return false
+}
+
 func (h *Hub) watchClusters() {
+	previousPhases := make(map[string]string)
+
 	for {
 		h.log.Info("Starting TenantCluster watch")
 
@@ -158,11 +284,28 @@ func (h *Hub) watchClusters() {
 					Payload: ClusterUpdatePayload{Cluster: event.Object},
 				}
 
+				// Detect phase transitions and emit notifications
+				if obj, ok := event.Object.(*unstructured.Unstructured); ok {
+					key := obj.GetNamespace() + "/" + obj.GetName()
+					newPhase, _, _ := unstructured.NestedString(obj.Object, "status", "phase")
+					prevPhase := previousPhases[key]
+
+					if newPhase != "" && newPhase != prevPhase {
+						previousPhases[key] = newPhase
+						if n := h.clusterPhaseNotification(obj, prevPhase, newPhase); n != nil {
+							h.BroadcastNotification(*n)
+						}
+					}
+				}
+
 			case watch.Deleted:
 				if obj, ok := event.Object.(interface {
 					GetName() string
 					GetNamespace() string
 				}); ok {
+					// Clean up phase tracking
+					delete(previousPhases, obj.GetNamespace()+"/"+obj.GetName())
+
 					h.broadcast <- Message{
 						Type: MessageTypeClusterDelete,
 						Payload: ClusterDeletePayload{
@@ -170,6 +313,18 @@ func (h *Hub) watchClusters() {
 							Namespace: obj.GetNamespace(),
 						},
 					}
+
+					h.BroadcastNotification(NotificationPayload{
+						Title:    fmt.Sprintf("Cluster %s deleted", obj.GetName()),
+						Message:  fmt.Sprintf("Cluster in namespace %s has been deleted", obj.GetNamespace()),
+						Severity: "warning",
+						Category: "cluster",
+						ResourceRef: &ResourceRef{
+							Kind:      "TenantCluster",
+							Name:      obj.GetName(),
+							Namespace: obj.GetNamespace(),
+						},
+					})
 				}
 
 			case watch.Error:
@@ -182,6 +337,54 @@ func (h *Hub) watchClusters() {
 	}
 }
 
+func (h *Hub) clusterPhaseNotification(obj *unstructured.Unstructured, oldPhase, newPhase string) *NotificationPayload {
+	name := obj.GetName()
+	ns := obj.GetNamespace()
+	teamRef, _, _ := unstructured.NestedString(obj.Object, "spec", "teamRef", "name")
+
+	ref := &ResourceRef{
+		Kind:      "TenantCluster",
+		Name:      name,
+		Namespace: ns,
+		Team:      teamRef,
+	}
+
+	switch newPhase {
+	case "Ready":
+		if oldPhase == "Provisioning" || oldPhase == "Updating" || oldPhase == "Installing" {
+			return &NotificationPayload{
+				Title:       fmt.Sprintf("Cluster %s is ready", name),
+				Message:     "Provisioning completed successfully.",
+				Severity:    "success",
+				Category:    "cluster",
+				ResourceRef: ref,
+			}
+		}
+	case "Failed":
+		failureMsg, _, _ := unstructured.NestedString(obj.Object, "status", "failureMessage")
+		if failureMsg == "" {
+			failureMsg = "Check cluster status for details."
+		}
+		return &NotificationPayload{
+			Title:       fmt.Sprintf("Cluster %s has failed", name),
+			Message:     failureMsg,
+			Severity:    "error",
+			Category:    "cluster",
+			ResourceRef: ref,
+		}
+	case "Degraded":
+		return &NotificationPayload{
+			Title:       fmt.Sprintf("Cluster %s is degraded", name),
+			Message:     "One or more components are unhealthy.",
+			Severity:    "warning",
+			Category:    "cluster",
+			ResourceRef: ref,
+		}
+	}
+
+	return nil
+}
+
 // HandleClusterWatch handles WebSocket connections for cluster updates.
 func (h *Hub) HandleClusterWatch(w http.ResponseWriter, r *http.Request) {
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -190,10 +393,24 @@ func (h *Hub) HandleClusterWatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Extract team memberships for per-client notification filtering
+	var teams []string
+	var isPlatformAdmin bool
+	if h.sessionResolver != nil {
+		if session, err := h.sessionResolver(r); err == nil && session != nil {
+			isPlatformAdmin = session.IsPlatformAdmin
+			for _, tm := range session.Teams {
+				teams = append(teams, tm.Name)
+			}
+		}
+	}
+
 	client := &Client{
-		hub:  h,
-		conn: conn,
-		send: make(chan Message, 256),
+		hub:             h,
+		conn:            conn,
+		send:            make(chan Message, 256),
+		teams:           teams,
+		isPlatformAdmin: isPlatformAdmin,
 	}
 
 	h.register <- client


### PR DESCRIPTION
## Summary
Extends the WebSocket hub to broadcast real-time notifications with per-client team filtering.

### Notification types
- Cluster lifecycle: Ready, Failed, Degraded phase transitions (from K8s watch)
- Cluster deletion notifications
- Team membership changes (from audit bridge)
- Security events: failed logins, user changes (from audit bridge)
- Infrastructure failures: provider/image sync issues (from audit bridge)

### Per-client team filtering
- Client struct extended with teams[] and isPlatformAdmin
- Session resolved from JWT cookie during WebSocket upgrade
- BroadcastNotification checks client teams before sending
- Platform admins receive all. Non-admins only receive notifications for their teams.
- Team-less notifications (security) sent to platform admins only.

### Phase transition tracking
- previousPhases map tracks cluster phases, only notifies on transitions
- Map entries cleaned up on watch.Deleted (prevents unbounded growth)

### Audit bridge
- New notifications.go rules engine (shouldNotify)
- Emitter.SetHub() bridges audit events to WebSocket notifications
- Maps team member add/remove, failed logins, provider failures, image sync failures

## Files
- `internal/websocket/hub.go` — notification types, per-client filtering, phase transitions, session resolver
- `internal/audit/emitter.go` — hub bridge
- `internal/audit/notifications.go` — rules engine
- `internal/api/router.go` — wire hub to emitter, session resolver