### PR TITLE
feat: add CLI device flow authentication (ADR-016)

### DIFF
--- a/internal/api/handlers/auth_device.go
+++ b/internal/api/handlers/auth_device.go
@@ -1,0 +1,369 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/butlerdotdev/butler-server/internal/audit"
+	"github.com/butlerdotdev/butler-server/internal/auth"
+	"github.com/butlerdotdev/butler-server/internal/config"
+)
+
+// DeviceFlowHandler handles the OAuth 2.0 Device Authorization Grant endpoints
+// used by the Butler CLI.
+type DeviceFlowHandler struct {
+	deviceStore    *auth.DeviceStore
+	saManager      *auth.CLIServiceAccountManager
+	teamResolver   *auth.TeamResolver
+	userService    *auth.UserService
+	sessionService *auth.SessionService
+	config         *config.Config
+	logger         *slog.Logger
+	auditEmitter   *audit.Emitter
+}
+
+// NewDeviceFlowHandler creates a new device flow handler.
+func NewDeviceFlowHandler(
+	deviceStore *auth.DeviceStore,
+	saManager *auth.CLIServiceAccountManager,
+	teamResolver *auth.TeamResolver,
+	userService *auth.UserService,
+	sessionService *auth.SessionService,
+	cfg *config.Config,
+	logger *slog.Logger,
+	auditEmitter *audit.Emitter,
+) *DeviceFlowHandler {
+	return &DeviceFlowHandler{
+		deviceStore:    deviceStore,
+		saManager:      saManager,
+		teamResolver:   teamResolver,
+		userService:    userService,
+		sessionService: sessionService,
+		config:         cfg,
+		logger:         logger,
+		auditEmitter:   auditEmitter,
+	}
+}
+
+// DeviceAuthorize initiates a device authorization flow.
+// POST /api/auth/cli/device
+func (h *DeviceFlowHandler) DeviceAuthorize(w http.ResponseWriter, r *http.Request) {
+	dc, err := h.deviceStore.Create(h.config.CLIAuth.DeviceCodeExpiry)
+	if err != nil {
+		h.logger.Error("Failed to create device code", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to create device code")
+		return
+	}
+
+	verificationURI := h.config.FrontendURL
+	if verificationURI == "" {
+		verificationURI = h.config.Server.BaseURL
+	}
+	verificationURI = verificationURI + "/auth/device"
+
+	h.logger.Info("Device authorization initiated",
+		"userCode", dc.UserCode,
+		"expiresIn", int(time.Until(dc.ExpiresAt).Seconds()),
+	)
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"device_code":      dc.DeviceCode,
+		"user_code":        dc.UserCode,
+		"verification_uri": verificationURI,
+		"expires_in":       int(time.Until(dc.ExpiresAt).Seconds()),
+		"interval":         dc.Interval,
+	})
+}
+
+// DeviceToken handles CLI polling for an approved device code.
+// POST /api/auth/cli/token
+func (h *DeviceFlowHandler) DeviceToken(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DeviceCode string `json:"device_code"`
+		ClientID   string `json:"client_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.DeviceCode == "" {
+		writeError(w, http.StatusBadRequest, "device_code is required")
+		return
+	}
+
+	dc, ok := h.deviceStore.Get(req.DeviceCode)
+	if !ok {
+		// Could be expired or never existed
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "expired_token"})
+		return
+	}
+
+	if dc.Denied {
+		h.deviceStore.Delete(req.DeviceCode)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "access_denied"})
+		return
+	}
+
+	if !dc.Approved {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "authorization_pending"})
+		return
+	}
+
+	// Approved -- provision SA, token, and kubeconfig
+	session := dc.UserSession
+	h.deviceStore.Delete(req.DeviceCode)
+
+	result, err := h.provisionCLIAccess(r, session)
+	if err != nil {
+		h.logger.Error("Failed to provision CLI access", "email", session.Email, "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to provision CLI access")
+		return
+	}
+
+	audit.RecordLogin(h.auditEmitter, session.Email, "cli-device", r.RemoteAddr)
+
+	h.logger.Info("CLI device flow completed",
+		"email", session.Email,
+		"teams", len(session.Teams),
+		"isPlatformAdmin", session.IsPlatformAdmin,
+	)
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// DeviceVerify validates a user code entered in the console.
+// POST /api/auth/cli/verify
+func (h *DeviceFlowHandler) DeviceVerify(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		UserCode string `json:"user_code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.UserCode == "" {
+		writeError(w, http.StatusBadRequest, "user_code is required")
+		return
+	}
+
+	dc, ok := h.deviceStore.GetByUserCode(req.UserCode)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Invalid or expired user code")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"device_code": dc.DeviceCode,
+		"expires_in":  int(time.Until(dc.ExpiresAt).Seconds()),
+	})
+}
+
+// DeviceApprove is called by an authenticated console user to approve a device code.
+// POST /api/auth/cli/approve
+func (h *DeviceFlowHandler) DeviceApprove(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+
+	var req struct {
+		DeviceCode string `json:"device_code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.DeviceCode == "" {
+		writeError(w, http.StatusBadRequest, "device_code is required")
+		return
+	}
+
+	dc, ok := h.deviceStore.Get(req.DeviceCode)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Invalid or expired device code")
+		return
+	}
+
+	if dc.Approved || dc.Denied {
+		writeError(w, http.StatusConflict, "Device code already resolved")
+		return
+	}
+
+	// Re-resolve teams to get the freshest membership data
+	teams, err := h.teamResolver.ResolveTeams(r.Context(), user.Email, user.Groups)
+	if err != nil {
+		h.logger.Warn("Failed to resolve teams during device approval", "email", user.Email, "error", err)
+		teams = user.Teams // fall back to session data
+	}
+
+	session := &auth.UserSession{
+		Subject:         user.Subject,
+		Email:           user.Email,
+		Name:            user.Name,
+		Picture:         user.Picture,
+		Provider:        user.Provider,
+		Groups:          user.Groups,
+		Teams:           teams,
+		IsPlatformAdmin: user.IsPlatformAdmin,
+	}
+
+	h.deviceStore.Approve(req.DeviceCode, session)
+
+	h.logger.Info("Device code approved",
+		"email", user.Email,
+		"deviceCode", dc.DeviceCode[:8]+"...",
+	)
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "approved"})
+}
+
+// DeviceRefresh exchanges a refresh token for a new SA token and kubeconfig.
+// POST /api/auth/cli/refresh
+func (h *DeviceFlowHandler) DeviceRefresh(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.RefreshToken == "" {
+		writeError(w, http.StatusBadRequest, "refresh_token is required")
+		return
+	}
+
+	email, ok := h.deviceStore.ValidateRefreshToken(req.RefreshToken)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "Invalid or expired refresh token")
+		return
+	}
+
+	// Check if user is disabled
+	userCRD, err := h.userService.GetUserByEmail(r.Context(), email)
+	if err != nil {
+		h.logger.Warn("Failed to look up user during CLI refresh", "email", email, "error", err)
+		writeError(w, http.StatusUnauthorized, "User not found")
+		return
+	}
+	if userCRD.Disabled {
+		h.logger.Warn("Disabled user attempted CLI refresh", "email", email)
+		writeError(w, http.StatusForbidden, "Account is disabled")
+		return
+	}
+
+	// Re-resolve teams
+	teams, err := h.teamResolver.ResolveTeams(r.Context(), email, nil)
+	if err != nil {
+		h.logger.Warn("Failed to resolve teams during CLI refresh", "email", email, "error", err)
+		teams = []auth.TeamMembership{}
+	}
+
+	session := &auth.UserSession{
+		Email:           email,
+		Name:            userCRD.DisplayName,
+		Teams:           teams,
+		IsPlatformAdmin: userCRD.IsPlatformAdmin,
+	}
+
+	result, err := h.provisionCLIAccess(r, session)
+	if err != nil {
+		h.logger.Error("Failed to provision CLI access on refresh", "email", email, "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to refresh CLI access")
+		return
+	}
+
+	h.logger.Info("CLI refresh completed", "email", email)
+	writeJSON(w, http.StatusOK, result)
+}
+
+// cliTokenResponse is the shape returned by both the token and refresh endpoints.
+type cliTokenResponse struct {
+	User              cliUserResponse `json:"user"`
+	Kubeconfig        string          `json:"kubeconfig"`
+	ExpiresAt         string          `json:"expires_at"`
+	RefreshToken      string          `json:"refresh_token"`
+	RefreshExpiresAt  string          `json:"refresh_expires_at"`
+}
+
+type cliUserResponse struct {
+	Email           string                `json:"email"`
+	Name            string                `json:"name"`
+	Teams           []auth.TeamMembership `json:"teams"`
+	IsPlatformAdmin bool                  `json:"isPlatformAdmin,omitempty"`
+}
+
+// provisionCLIAccess creates (or updates) the SA, RoleBindings, token, and
+// kubeconfig for a CLI user. It returns the response payload.
+func (h *DeviceFlowHandler) provisionCLIAccess(r *http.Request, session *auth.UserSession) (*cliTokenResponse, error) {
+	ctx := r.Context()
+
+	// Ensure ServiceAccount
+	sa, err := h.saManager.EnsureServiceAccount(ctx, session.Email)
+	if err != nil {
+		return nil, fmt.Errorf("ensure service account: %w", err)
+	}
+
+	// Ensure RoleBindings
+	if err := h.saManager.EnsureRoleBindings(ctx, sa.Name, session.Email, session.Teams, session.IsPlatformAdmin); err != nil {
+		return nil, fmt.Errorf("ensure role bindings: %w", err)
+	}
+
+	// Create short-lived SA token
+	token, expiresAt, err := h.saManager.CreateToken(ctx, sa.Name)
+	if err != nil {
+		return nil, fmt.Errorf("create token: %w", err)
+	}
+
+	// Build kubeconfig
+	kubeconfigBytes, err := h.saManager.BuildKubeconfig(token, sa.Name)
+	if err != nil {
+		return nil, fmt.Errorf("build kubeconfig: %w", err)
+	}
+
+	// Generate refresh token
+	refreshToken, err := auth.GenerateRefreshToken()
+	if err != nil {
+		return nil, fmt.Errorf("generate refresh token: %w", err)
+	}
+
+	refreshExpiresAt := time.Now().Add(h.config.CLIAuth.RefreshExpiry)
+	h.deviceStore.StoreRefreshToken(refreshToken, session.Email, h.config.CLIAuth.RefreshExpiry)
+
+	return &cliTokenResponse{
+		User: cliUserResponse{
+			Email:           session.Email,
+			Name:            session.Name,
+			Teams:           session.Teams,
+			IsPlatformAdmin: session.IsPlatformAdmin,
+		},
+		Kubeconfig:       base64.StdEncoding.EncodeToString(kubeconfigBytes),
+		ExpiresAt:        expiresAt.Format(time.RFC3339),
+		RefreshToken:     refreshToken,
+		RefreshExpiresAt: refreshExpiresAt.Format(time.RFC3339),
+	}, nil
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/butlerdotdev/butler-server/internal/api/handlers"
 	"github.com/butlerdotdev/butler-server/internal/audit"
@@ -150,6 +151,36 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 		return info, nil
 	})
 
+	// Initialize device flow for CLI authentication
+	var deviceFlowHandler *handlers.DeviceFlowHandler
+	if cfg.Config.CLIAuth.Enabled {
+		deviceStore := auth.NewDeviceStore()
+		deviceStore.StartCleanup(context.Background(), 1*time.Minute)
+
+		saManager := auth.NewCLIServiceAccountManager(
+			cfg.K8sClient.Clientset(),
+			cfg.K8sClient.Config(),
+			cfg.Logger.With("component", "cli-sa-manager"),
+			cfg.Config.SystemNamespace,
+			cfg.Config.CLIAuth.TokenExpiry,
+		)
+
+		deviceFlowHandler = handlers.NewDeviceFlowHandler(
+			deviceStore,
+			saManager,
+			teamResolver,
+			userService,
+			sessionService,
+			cfg.Config,
+			cfg.Logger.With("component", "cli-device-flow"),
+			auditEmitter,
+		)
+
+		cfg.Logger.Info("CLI device flow authentication enabled")
+	} else {
+		cfg.Logger.Info("CLI device flow authentication disabled")
+	}
+
 	// Initialize handlers
 	authHandler := handlers.NewAuthHandler(
 		oidcProvider,
@@ -213,6 +244,14 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			// Invite flow (public - user clicking invite link)
 			r.Get("/invite/{token}", userHandler.ValidateInvite)
 			r.Post("/set-password", userHandler.SetPassword)
+
+			// CLI device flow (public endpoints)
+			if deviceFlowHandler != nil {
+				r.Post("/cli/device", deviceFlowHandler.DeviceAuthorize)
+				r.Post("/cli/token", deviceFlowHandler.DeviceToken)
+				r.Post("/cli/verify", deviceFlowHandler.DeviceVerify)
+				r.Post("/cli/refresh", deviceFlowHandler.DeviceRefresh)
+			}
 		})
 
 		// Protected routes (authentication required)
@@ -226,6 +265,11 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			r.Post("/auth/refresh-permissions", authHandler.RefreshPermissions)
 			r.Get("/auth/me", authHandler.Me)
 			r.Get("/auth/teams", authHandler.Teams)
+
+			// CLI device flow approval (requires authenticated session)
+			if deviceFlowHandler != nil {
+				r.Post("/auth/cli/approve", deviceFlowHandler.DeviceApprove)
+			}
 
 			// Management cluster
 			r.Get("/management", clusterHandler.GetManagement)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -163,6 +163,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			cfg.Logger.With("component", "cli-sa-manager"),
 			cfg.Config.SystemNamespace,
 			cfg.Config.CLIAuth.TokenExpiry,
+			cfg.Config.CLIAuth.ExternalAPIURL,
 		)
 
 		deviceFlowHandler = handlers.NewDeviceFlowHandler(

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// userCodeAlphabet excludes ambiguous characters: 0/O, 1/I/L.
+const userCodeAlphabet = "ABCDEFGHJKMNPQRSTUVWXYZ"
+
+// DeviceCode represents a pending device authorization request.
+type DeviceCode struct {
+	DeviceCode  string
+	UserCode    string
+	ExpiresAt   time.Time
+	Interval    int // polling interval in seconds
+	Approved    bool
+	Denied      bool
+	UserSession *UserSession // set when approved
+}
+
+// RefreshEntry maps a hashed refresh token to the user email it was issued for.
+type RefreshEntry struct {
+	Email     string
+	ExpiresAt time.Time
+}
+
+// DeviceStore manages pending device authorization codes and refresh tokens.
+type DeviceStore struct {
+	mu         sync.RWMutex
+	codes      map[string]*DeviceCode // keyed by device_code
+	byUserCode map[string]string      // user_code -> device_code lookup
+
+	refreshMu     sync.RWMutex
+	refreshTokens map[string]*RefreshEntry // keyed by sha256(token)
+}
+
+// NewDeviceStore creates a new device code store.
+func NewDeviceStore() *DeviceStore {
+	return &DeviceStore{
+		codes:         make(map[string]*DeviceCode),
+		byUserCode:    make(map[string]string),
+		refreshTokens: make(map[string]*RefreshEntry),
+	}
+}
+
+// Create generates a new device code and user code pair, stores them with the
+// given TTL, and returns the DeviceCode.
+func (s *DeviceStore) Create(expiry time.Duration) (*DeviceCode, error) {
+	deviceCode, err := generateRandomHex(32)
+	if err != nil {
+		return nil, err
+	}
+
+	userCode, err := generateUserCode()
+	if err != nil {
+		return nil, err
+	}
+
+	dc := &DeviceCode{
+		DeviceCode: deviceCode,
+		UserCode:   userCode,
+		ExpiresAt:  time.Now().Add(expiry),
+		Interval:   5,
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.codes[deviceCode] = dc
+	s.byUserCode[userCode] = deviceCode
+
+	return dc, nil
+}
+
+// Get returns the device code entry if it exists and has not expired.
+func (s *DeviceStore) Get(deviceCode string) (*DeviceCode, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dc, ok := s.codes[deviceCode]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(dc.ExpiresAt) {
+		return nil, false
+	}
+	return dc, true
+}
+
+// GetByUserCode looks up a device code entry by the human-readable user code.
+func (s *DeviceStore) GetByUserCode(userCode string) (*DeviceCode, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	deviceCode, ok := s.byUserCode[userCode]
+	if !ok {
+		return nil, false
+	}
+	dc, ok := s.codes[deviceCode]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(dc.ExpiresAt) {
+		return nil, false
+	}
+	return dc, true
+}
+
+// Approve marks a device code as approved and attaches the authenticated user session.
+func (s *DeviceStore) Approve(deviceCode string, session *UserSession) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if dc, ok := s.codes[deviceCode]; ok {
+		dc.Approved = true
+		dc.UserSession = session
+	}
+}
+
+// Deny marks a device code as denied by the user.
+func (s *DeviceStore) Deny(deviceCode string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if dc, ok := s.codes[deviceCode]; ok {
+		dc.Denied = true
+	}
+}
+
+// Delete removes a device code after it has been consumed.
+func (s *DeviceStore) Delete(deviceCode string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if dc, ok := s.codes[deviceCode]; ok {
+		delete(s.byUserCode, dc.UserCode)
+		delete(s.codes, deviceCode)
+	}
+}
+
+// Cleanup removes all expired device codes.
+func (s *DeviceStore) Cleanup() {
+	s.mu.Lock()
+	now := time.Now()
+	for code, dc := range s.codes {
+		if now.After(dc.ExpiresAt) {
+			delete(s.byUserCode, dc.UserCode)
+			delete(s.codes, code)
+		}
+	}
+	s.mu.Unlock()
+
+	s.refreshMu.Lock()
+	for hash, entry := range s.refreshTokens {
+		if now.After(entry.ExpiresAt) {
+			delete(s.refreshTokens, hash)
+		}
+	}
+	s.refreshMu.Unlock()
+}
+
+// StartCleanup runs a background goroutine that periodically removes expired entries.
+// It stops when the provided context is cancelled.
+func (s *DeviceStore) StartCleanup(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.Cleanup()
+			}
+		}
+	}()
+}
+
+// StoreRefreshToken stores a refresh token mapping to the given email.
+// The token is stored as its SHA-256 hash.
+func (s *DeviceStore) StoreRefreshToken(token, email string, expiry time.Duration) {
+	hash := hashRefreshToken(token)
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+	s.refreshTokens[hash] = &RefreshEntry{
+		Email:     email,
+		ExpiresAt: time.Now().Add(expiry),
+	}
+}
+
+// ValidateRefreshToken checks whether a refresh token is valid and returns
+// the associated email. The token is consumed (deleted) on success.
+func (s *DeviceStore) ValidateRefreshToken(token string) (string, bool) {
+	hash := hashRefreshToken(token)
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	entry, ok := s.refreshTokens[hash]
+	if !ok {
+		return "", false
+	}
+	// Consume the token (rotate-on-use)
+	delete(s.refreshTokens, hash)
+
+	if time.Now().After(entry.ExpiresAt) {
+		return "", false
+	}
+	return entry.Email, true
+}
+
+// GenerateRefreshToken produces a 32-byte cryptographically random token,
+// returned as a 64-character hex string.
+func GenerateRefreshToken() (string, error) {
+	return generateRandomHex(32)
+}
+
+// generateRandomHex produces n random bytes and returns them hex-encoded.
+func generateRandomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// generateUserCode produces an 8-character code in XXXX-XXXX format using
+// only unambiguous uppercase letters.
+func generateUserCode() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	code := make([]byte, 8)
+	for i := range code {
+		code[i] = userCodeAlphabet[int(b[i])%len(userCodeAlphabet)]
+	}
+	return string(code[:4]) + "-" + string(code[4:]), nil
+}
+
+// hashRefreshToken returns the SHA-256 hex digest of a refresh token.
+func hashRefreshToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -1,0 +1,395 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeviceStoreCreate(t *testing.T) {
+	hexPattern := regexp.MustCompile(`^[0-9a-f]{64}$`)
+	userCodePattern := regexp.MustCompile(`^[A-Z]{4}-[A-Z]{4}$`)
+
+	t.Run("device code is 64 hex characters", func(t *testing.T) {
+		store := NewDeviceStore()
+		dc, err := store.Create(5 * time.Minute)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if !hexPattern.MatchString(dc.DeviceCode) {
+			t.Errorf("device code %q does not match expected 64-char hex pattern", dc.DeviceCode)
+		}
+	})
+
+	t.Run("user code is XXXX-XXXX uppercase alpha", func(t *testing.T) {
+		store := NewDeviceStore()
+		dc, err := store.Create(5 * time.Minute)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if !userCodePattern.MatchString(dc.UserCode) {
+			t.Errorf("user code %q does not match XXXX-XXXX pattern", dc.UserCode)
+		}
+	})
+
+	t.Run("codes are unique across calls", func(t *testing.T) {
+		store := NewDeviceStore()
+		seen := make(map[string]bool)
+		for i := 0; i < 100; i++ {
+			dc, err := store.Create(5 * time.Minute)
+			if err != nil {
+				t.Fatalf("Create iteration %d: %v", i, err)
+			}
+			if seen[dc.DeviceCode] {
+				t.Fatalf("duplicate device code on iteration %d: %s", i, dc.DeviceCode)
+			}
+			if seen[dc.UserCode] {
+				t.Fatalf("duplicate user code on iteration %d: %s", i, dc.UserCode)
+			}
+			seen[dc.DeviceCode] = true
+			seen[dc.UserCode] = true
+		}
+	})
+
+	t.Run("expiry and interval are set", func(t *testing.T) {
+		store := NewDeviceStore()
+		before := time.Now()
+		dc, err := store.Create(10 * time.Minute)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		after := time.Now()
+
+		if dc.ExpiresAt.Before(before.Add(10*time.Minute)) || dc.ExpiresAt.After(after.Add(10*time.Minute)) {
+			t.Errorf("ExpiresAt %v not within expected range", dc.ExpiresAt)
+		}
+		if dc.Interval != 5 {
+			t.Errorf("Interval = %d, want 5", dc.Interval)
+		}
+		if dc.Approved || dc.Denied {
+			t.Error("newly created code should not be approved or denied")
+		}
+		if dc.UserSession != nil {
+			t.Error("newly created code should have nil UserSession")
+		}
+	})
+}
+
+func TestDeviceStoreGet(t *testing.T) {
+	t.Run("existing code", func(t *testing.T) {
+		store := NewDeviceStore()
+		dc, err := store.Create(5 * time.Minute)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		got, ok := store.Get(dc.DeviceCode)
+		if !ok {
+			t.Fatal("Get returned false for existing code")
+		}
+		if got.DeviceCode != dc.DeviceCode {
+			t.Errorf("Get returned device code %q, want %q", got.DeviceCode, dc.DeviceCode)
+		}
+		if got.UserCode != dc.UserCode {
+			t.Errorf("Get returned user code %q, want %q", got.UserCode, dc.UserCode)
+		}
+	})
+
+	t.Run("expired code returns false", func(t *testing.T) {
+		store := NewDeviceStore()
+		dc, err := store.Create(1 * time.Nanosecond)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+		_, ok := store.Get(dc.DeviceCode)
+		if ok {
+			t.Error("Get returned true for expired code")
+		}
+	})
+
+	t.Run("nonexistent code returns false", func(t *testing.T) {
+		store := NewDeviceStore()
+		_, ok := store.Get("does-not-exist")
+		if ok {
+			t.Error("Get returned true for nonexistent code")
+		}
+	})
+}
+
+func TestDeviceStoreGetByUserCode(t *testing.T) {
+	t.Run("lookup works", func(t *testing.T) {
+		store := NewDeviceStore()
+		dc, err := store.Create(5 * time.Minute)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		got, ok := store.GetByUserCode(dc.UserCode)
+		if !ok {
+			t.Fatal("GetByUserCode returned false for existing user code")
+		}
+		if got.DeviceCode != dc.DeviceCode {
+			t.Errorf("GetByUserCode returned device code %q, want %q", got.DeviceCode, dc.DeviceCode)
+		}
+	})
+
+	t.Run("expired code returns false", func(t *testing.T) {
+		store := NewDeviceStore()
+		dc, err := store.Create(1 * time.Nanosecond)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+		_, ok := store.GetByUserCode(dc.UserCode)
+		if ok {
+			t.Error("GetByUserCode returned true for expired code")
+		}
+	})
+
+	t.Run("nonexistent user code returns false", func(t *testing.T) {
+		store := NewDeviceStore()
+		_, ok := store.GetByUserCode("ZZZZ-ZZZZ")
+		if ok {
+			t.Error("GetByUserCode returned true for nonexistent user code")
+		}
+	})
+}
+
+func TestDeviceStoreApprove(t *testing.T) {
+	t.Run("sets approved and attaches session", func(t *testing.T) {
+		store := NewDeviceStore()
+		dc, err := store.Create(5 * time.Minute)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+
+		session := &UserSession{
+			Email: "alice@example.com",
+			Name:  "Alice",
+			Teams: []TeamMembership{{Name: "platform", Role: "admin"}},
+		}
+		store.Approve(dc.DeviceCode, session)
+
+		got, ok := store.Get(dc.DeviceCode)
+		if !ok {
+			t.Fatal("Get returned false after approval")
+		}
+		if !got.Approved {
+			t.Error("Approved should be true after Approve()")
+		}
+		if got.Denied {
+			t.Error("Denied should be false after Approve()")
+		}
+		if got.UserSession == nil {
+			t.Fatal("UserSession should be set after Approve()")
+		}
+		if got.UserSession.Email != "alice@example.com" {
+			t.Errorf("UserSession.Email = %q, want %q", got.UserSession.Email, "alice@example.com")
+		}
+	})
+
+	t.Run("approve nonexistent code is a no-op", func(t *testing.T) {
+		store := NewDeviceStore()
+		// Must not panic.
+		store.Approve("nonexistent", &UserSession{Email: "bob@example.com"})
+	})
+}
+
+func TestDeviceStoreDeny(t *testing.T) {
+	t.Run("sets denied state", func(t *testing.T) {
+		store := NewDeviceStore()
+		dc, err := store.Create(5 * time.Minute)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		store.Deny(dc.DeviceCode)
+
+		got, ok := store.Get(dc.DeviceCode)
+		if !ok {
+			t.Fatal("Get returned false after denial")
+		}
+		if !got.Denied {
+			t.Error("Denied should be true after Deny()")
+		}
+		if got.Approved {
+			t.Error("Approved should be false after Deny()")
+		}
+	})
+
+	t.Run("deny nonexistent code is a no-op", func(t *testing.T) {
+		store := NewDeviceStore()
+		// Must not panic.
+		store.Deny("nonexistent")
+	})
+}
+
+func TestDeviceStoreCleanup(t *testing.T) {
+	t.Run("removes expired codes and keeps valid ones", func(t *testing.T) {
+		store := NewDeviceStore()
+
+		// Create an already-expired code.
+		expired, err := store.Create(1 * time.Nanosecond)
+		if err != nil {
+			t.Fatalf("Create expired: %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+
+		// Create a code that is still valid.
+		valid, err := store.Create(5 * time.Minute)
+		if err != nil {
+			t.Fatalf("Create valid: %v", err)
+		}
+
+		store.Cleanup()
+
+		// Expired code should be gone from both maps (Get already filters by
+		// expiry, so check the underlying map through a second Create/Get cycle
+		// is not needed -- we verify the user code lookup is also cleaned).
+		if _, ok := store.GetByUserCode(expired.UserCode); ok {
+			t.Error("expired user code still found after Cleanup")
+		}
+
+		// Valid code should still be present.
+		if _, ok := store.Get(valid.DeviceCode); !ok {
+			t.Error("valid device code missing after Cleanup")
+		}
+		if _, ok := store.GetByUserCode(valid.UserCode); !ok {
+			t.Error("valid user code missing after Cleanup")
+		}
+	})
+
+	t.Run("removes expired refresh tokens", func(t *testing.T) {
+		store := NewDeviceStore()
+
+		store.StoreRefreshToken("expired-token", "alice@example.com", 1*time.Nanosecond)
+		time.Sleep(2 * time.Millisecond)
+		store.StoreRefreshToken("valid-token", "bob@example.com", 5*time.Minute)
+
+		store.Cleanup()
+
+		if _, ok := store.ValidateRefreshToken("expired-token"); ok {
+			t.Error("expired refresh token still valid after Cleanup")
+		}
+		if email, ok := store.ValidateRefreshToken("valid-token"); !ok {
+			t.Error("valid refresh token missing after Cleanup")
+		} else if email != "bob@example.com" {
+			t.Errorf("ValidateRefreshToken email = %q, want %q", email, "bob@example.com")
+		}
+	})
+}
+
+func TestRefreshTokenRoundTrip(t *testing.T) {
+	t.Run("store and validate", func(t *testing.T) {
+		store := NewDeviceStore()
+		store.StoreRefreshToken("my-token", "alice@example.com", 5*time.Minute)
+
+		email, ok := store.ValidateRefreshToken("my-token")
+		if !ok {
+			t.Fatal("ValidateRefreshToken returned false for valid token")
+		}
+		if email != "alice@example.com" {
+			t.Errorf("email = %q, want %q", email, "alice@example.com")
+		}
+	})
+
+	t.Run("rotate on use: second validate fails", func(t *testing.T) {
+		store := NewDeviceStore()
+		store.StoreRefreshToken("one-time-token", "bob@example.com", 5*time.Minute)
+
+		if _, ok := store.ValidateRefreshToken("one-time-token"); !ok {
+			t.Fatal("first ValidateRefreshToken should succeed")
+		}
+		if _, ok := store.ValidateRefreshToken("one-time-token"); ok {
+			t.Error("second ValidateRefreshToken should fail (rotate-on-use)")
+		}
+	})
+
+	t.Run("expired refresh token returns false", func(t *testing.T) {
+		store := NewDeviceStore()
+		store.StoreRefreshToken("stale-token", "charlie@example.com", 1*time.Nanosecond)
+		time.Sleep(2 * time.Millisecond)
+
+		if _, ok := store.ValidateRefreshToken("stale-token"); ok {
+			t.Error("ValidateRefreshToken should return false for expired token")
+		}
+	})
+
+	t.Run("nonexistent token returns false", func(t *testing.T) {
+		store := NewDeviceStore()
+		if _, ok := store.ValidateRefreshToken("no-such-token"); ok {
+			t.Error("ValidateRefreshToken should return false for nonexistent token")
+		}
+	})
+}
+
+func TestGenerateRefreshToken(t *testing.T) {
+	t.Run("produces 64 hex characters", func(t *testing.T) {
+		token, err := GenerateRefreshToken()
+		if err != nil {
+			t.Fatalf("GenerateRefreshToken: %v", err)
+		}
+		matched, _ := regexp.MatchString(`^[0-9a-f]{64}$`, token)
+		if !matched {
+			t.Errorf("token %q does not match 64-char hex pattern", token)
+		}
+	})
+
+	t.Run("two calls produce different tokens", func(t *testing.T) {
+		a, err := GenerateRefreshToken()
+		if err != nil {
+			t.Fatalf("GenerateRefreshToken (1): %v", err)
+		}
+		b, err := GenerateRefreshToken()
+		if err != nil {
+			t.Fatalf("GenerateRefreshToken (2): %v", err)
+		}
+		if a == b {
+			t.Errorf("two consecutive calls returned the same token: %s", a)
+		}
+	})
+}
+
+func TestUserCodeCharacterSet(t *testing.T) {
+	ambiguous := "01OIL"
+
+	t.Run("alphabet excludes ambiguous characters", func(t *testing.T) {
+		for _, ch := range ambiguous {
+			if strings.ContainsRune(userCodeAlphabet, ch) {
+				t.Errorf("userCodeAlphabet contains ambiguous character %q", string(ch))
+			}
+		}
+	})
+
+	t.Run("generated user codes contain no ambiguous characters", func(t *testing.T) {
+		store := NewDeviceStore()
+		for i := 0; i < 200; i++ {
+			dc, err := store.Create(5 * time.Minute)
+			if err != nil {
+				t.Fatalf("Create iteration %d: %v", i, err)
+			}
+			// Strip the dash before checking individual characters.
+			raw := strings.ReplaceAll(dc.UserCode, "-", "")
+			for _, ch := range raw {
+				if strings.ContainsRune(ambiguous, ch) {
+					t.Errorf("user code %q contains ambiguous character %q", dc.UserCode, string(ch))
+				}
+			}
+		}
+	})
+}

--- a/internal/auth/serviceaccount.go
+++ b/internal/auth/serviceaccount.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -63,11 +64,12 @@ const (
 
 // CLIServiceAccountManager handles ServiceAccount lifecycle for CLI users.
 type CLIServiceAccountManager struct {
-	clientset   kubernetes.Interface
-	config      *rest.Config
-	logger      *slog.Logger
-	namespace   string
-	tokenExpiry time.Duration
+	clientset      kubernetes.Interface
+	config         *rest.Config
+	logger         *slog.Logger
+	namespace      string
+	tokenExpiry    time.Duration
+	externalAPIURL string // external K8s API URL for kubeconfigs (overrides config.Host)
 }
 
 // NewCLIServiceAccountManager creates a new manager.
@@ -77,13 +79,15 @@ func NewCLIServiceAccountManager(
 	logger *slog.Logger,
 	namespace string,
 	tokenExpiry time.Duration,
+	externalAPIURL string,
 ) *CLIServiceAccountManager {
 	return &CLIServiceAccountManager{
-		clientset:   clientset,
-		config:      config,
-		logger:      logger,
-		namespace:   namespace,
-		tokenExpiry: tokenExpiry,
+		clientset:      clientset,
+		config:         config,
+		logger:         logger,
+		namespace:      namespace,
+		tokenExpiry:    tokenExpiry,
+		externalAPIURL: externalAPIURL,
 	}
 }
 
@@ -313,13 +317,25 @@ func (m *CLIServiceAccountManager) BuildKubeconfig(token, saName string) ([]byte
 	userName := saName
 
 	kubeconfig := clientcmdapi.NewConfig()
-	kubeconfig.Clusters[clusterName] = &clientcmdapi.Cluster{
-		Server:                   m.config.Host,
-		CertificateAuthorityData: m.config.CAData,
+	caData := m.config.CAData
+	// When running in-cluster, CAData is empty and CAFile points to the
+	// in-cluster CA certificate. Read it so the kubeconfig is self-contained.
+	if len(caData) == 0 && m.config.CAFile != "" {
+		data, err := os.ReadFile(m.config.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading CA certificate from %s: %w", m.config.CAFile, err)
+		}
+		caData = data
 	}
-	// If no CA data but a CA file is set, reference it
-	if len(kubeconfig.Clusters[clusterName].CertificateAuthorityData) == 0 && m.config.CAFile != "" {
-		kubeconfig.Clusters[clusterName].CertificateAuthority = m.config.CAFile
+
+	serverURL := m.config.Host
+	if m.externalAPIURL != "" {
+		serverURL = m.externalAPIURL
+	}
+
+	kubeconfig.Clusters[clusterName] = &clientcmdapi.Cluster{
+		Server:                   serverURL,
+		CertificateAuthorityData: caData,
 	}
 
 	kubeconfig.AuthInfos[userName] = &clientcmdapi.AuthInfo{

--- a/internal/auth/serviceaccount.go
+++ b/internal/auth/serviceaccount.go
@@ -1,0 +1,400 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	clientcmd "k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	// CLIServiceAccountPrefix is the naming prefix for CLI-issued ServiceAccounts.
+	CLIServiceAccountPrefix = "butler-cli-"
+
+	// CLIUserLabel marks a ServiceAccount as managed by the CLI auth flow.
+	CLIUserLabel = "butler.butlerlabs.dev/cli-user"
+
+	// CLIEmailAnnotation stores the user's email on the ServiceAccount.
+	CLIEmailAnnotation = "butler.butlerlabs.dev/cli-email"
+
+	// CLILastLoginAnnotation tracks when the SA was last used.
+	CLILastLoginAnnotation = "butler.butlerlabs.dev/cli-last-login"
+
+	// CLIClusterRolePlatformAdmin is bound to platform admins.
+	CLIClusterRolePlatformAdmin = "butler-cli-platform-admin"
+
+	// CLIClusterRoleAdmin is bound for team-admin access.
+	CLIClusterRoleAdmin = "butler-cli-admin"
+
+	// CLIClusterRoleOperator is bound for team-operator access.
+	CLIClusterRoleOperator = "butler-cli-operator"
+
+	// CLIClusterRoleViewer is bound for team-viewer access.
+	CLIClusterRoleViewer = "butler-cli-viewer"
+)
+
+// CLIServiceAccountManager handles ServiceAccount lifecycle for CLI users.
+type CLIServiceAccountManager struct {
+	clientset   kubernetes.Interface
+	config      *rest.Config
+	logger      *slog.Logger
+	namespace   string
+	tokenExpiry time.Duration
+}
+
+// NewCLIServiceAccountManager creates a new manager.
+func NewCLIServiceAccountManager(
+	clientset kubernetes.Interface,
+	config *rest.Config,
+	logger *slog.Logger,
+	namespace string,
+	tokenExpiry time.Duration,
+) *CLIServiceAccountManager {
+	return &CLIServiceAccountManager{
+		clientset:   clientset,
+		config:      config,
+		logger:      logger,
+		namespace:   namespace,
+		tokenExpiry: tokenExpiry,
+	}
+}
+
+// saNameForEmail derives a deterministic ServiceAccount name from an email address.
+func saNameForEmail(email string) string {
+	h := sha256.Sum256([]byte(email))
+	return CLIServiceAccountPrefix + hex.EncodeToString(h[:])[:12]
+}
+
+// EnsureServiceAccount creates or updates a ServiceAccount for the given user.
+func (m *CLIServiceAccountManager) EnsureServiceAccount(ctx context.Context, email string) (*corev1.ServiceAccount, error) {
+	name := saNameForEmail(email)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	sa, err := m.clientset.CoreV1().ServiceAccounts(m.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err == nil {
+		// Update last-login annotation
+		if sa.Annotations == nil {
+			sa.Annotations = make(map[string]string)
+		}
+		sa.Annotations[CLILastLoginAnnotation] = now
+		updated, updateErr := m.clientset.CoreV1().ServiceAccounts(m.namespace).Update(ctx, sa, metav1.UpdateOptions{})
+		if updateErr != nil {
+			return nil, fmt.Errorf("failed to update service account: %w", updateErr)
+		}
+		m.logger.Info("Updated CLI service account", "name", name, "email", email)
+		return updated, nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get service account: %w", err)
+	}
+
+	// Create new SA
+	sa = &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: m.namespace,
+			Labels: map[string]string{
+				CLIUserLabel:                    "true",
+				"app.kubernetes.io/managed-by":  "butler",
+				"app.kubernetes.io/component":   "cli-auth",
+			},
+			Annotations: map[string]string{
+				CLIEmailAnnotation:     email,
+				CLILastLoginAnnotation: now,
+			},
+		},
+	}
+
+	created, err := m.clientset.CoreV1().ServiceAccounts(m.namespace).Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create service account: %w", err)
+	}
+
+	m.logger.Info("Created CLI service account", "name", name, "email", email)
+	return created, nil
+}
+
+// EnsureRoleBindings creates or updates RoleBindings in each team namespace for
+// the user, and a ClusterRoleBinding for platform admins. Stale bindings for
+// teams the user no longer belongs to are cleaned up.
+func (m *CLIServiceAccountManager) EnsureRoleBindings(
+	ctx context.Context,
+	saName string,
+	email string,
+	teams []TeamMembership,
+	isPlatformAdmin bool,
+) error {
+	// Build the set of desired team namespaces so we can GC stale bindings
+	desiredNamespaces := make(map[string]bool, len(teams))
+
+	for _, tm := range teams {
+		ns := tm.Name // Team namespace follows the team name convention
+		desiredNamespaces[ns] = true
+
+		clusterRole := clusterRoleForTeamRole(tm.Role)
+		rbName := fmt.Sprintf("%s-%s", saName, tm.Name)
+
+		desired := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rbName,
+				Namespace: ns,
+				Labels: map[string]string{
+					CLIUserLabel:                   "true",
+					"app.kubernetes.io/managed-by": "butler",
+				},
+				Annotations: map[string]string{
+					CLIEmailAnnotation: email,
+				},
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      saName,
+					Namespace: m.namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     clusterRole,
+			},
+		}
+
+		existing, err := m.clientset.RbacV1().RoleBindings(ns).Get(ctx, rbName, metav1.GetOptions{})
+		if err == nil {
+			// Update if the role ref changed (requires delete+create since RoleRef is immutable)
+			if existing.RoleRef.Name != clusterRole {
+				if delErr := m.clientset.RbacV1().RoleBindings(ns).Delete(ctx, rbName, metav1.DeleteOptions{}); delErr != nil {
+					m.logger.Warn("Failed to delete stale role binding for update", "name", rbName, "namespace", ns, "error", delErr)
+				}
+				if _, createErr := m.clientset.RbacV1().RoleBindings(ns).Create(ctx, desired, metav1.CreateOptions{}); createErr != nil {
+					return fmt.Errorf("failed to recreate role binding %s/%s: %w", ns, rbName, createErr)
+				}
+			}
+			continue
+		}
+
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get role binding %s/%s: %w", ns, rbName, err)
+		}
+
+		if _, err := m.clientset.RbacV1().RoleBindings(ns).Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create role binding %s/%s: %w", ns, rbName, err)
+			}
+		}
+	}
+
+	// Platform admin ClusterRoleBinding
+	crbName := saName + "-platform-admin"
+	if isPlatformAdmin {
+		desired := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crbName,
+				Labels: map[string]string{
+					CLIUserLabel:                   "true",
+					"app.kubernetes.io/managed-by": "butler",
+				},
+				Annotations: map[string]string{
+					CLIEmailAnnotation: email,
+				},
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      saName,
+					Namespace: m.namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     CLIClusterRolePlatformAdmin,
+			},
+		}
+
+		_, err := m.clientset.RbacV1().ClusterRoleBindings().Get(ctx, crbName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			if _, createErr := m.clientset.RbacV1().ClusterRoleBindings().Create(ctx, desired, metav1.CreateOptions{}); createErr != nil {
+				if !apierrors.IsAlreadyExists(createErr) {
+					return fmt.Errorf("failed to create cluster role binding %s: %w", crbName, createErr)
+				}
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to get cluster role binding %s: %w", crbName, err)
+		}
+	} else {
+		// Remove platform admin CRB if user is no longer an admin
+		err := m.clientset.RbacV1().ClusterRoleBindings().Delete(ctx, crbName, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			m.logger.Warn("Failed to delete stale platform admin cluster role binding", "name", crbName, "error", err)
+		}
+	}
+
+	// Clean up stale RoleBindings for teams the user is no longer in.
+	// List all RBs with our label and SA annotation matching this email.
+	allRBs, err := m.clientset.RbacV1().RoleBindings("").List(ctx, metav1.ListOptions{
+		LabelSelector: CLIUserLabel + "=true",
+	})
+	if err != nil {
+		m.logger.Warn("Failed to list role bindings for cleanup", "error", err)
+		return nil // non-fatal
+	}
+
+	for _, rb := range allRBs.Items {
+		if rb.Annotations[CLIEmailAnnotation] != email {
+			continue
+		}
+		if desiredNamespaces[rb.Namespace] {
+			continue
+		}
+		// This binding is for a team the user no longer belongs to
+		if delErr := m.clientset.RbacV1().RoleBindings(rb.Namespace).Delete(ctx, rb.Name, metav1.DeleteOptions{}); delErr != nil {
+			m.logger.Warn("Failed to delete stale role binding", "name", rb.Name, "namespace", rb.Namespace, "error", delErr)
+		} else {
+			m.logger.Info("Cleaned up stale CLI role binding", "name", rb.Name, "namespace", rb.Namespace, "email", email)
+		}
+	}
+
+	return nil
+}
+
+// CreateToken creates a short-lived ServiceAccount token via the TokenRequest API.
+func (m *CLIServiceAccountManager) CreateToken(ctx context.Context, saName string) (string, time.Time, error) {
+	expirationSeconds := int64(m.tokenExpiry.Seconds())
+	req := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			ExpirationSeconds: &expirationSeconds,
+		},
+	}
+
+	resp, err := m.clientset.CoreV1().ServiceAccounts(m.namespace).CreateToken(ctx, saName, req, metav1.CreateOptions{})
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to create token: %w", err)
+	}
+
+	return resp.Status.Token, resp.Status.ExpirationTimestamp.Time, nil
+}
+
+// BuildKubeconfig assembles a kubeconfig YAML from the SA token and the
+// management cluster's CA and server URL.
+func (m *CLIServiceAccountManager) BuildKubeconfig(token, saName string) ([]byte, error) {
+	clusterName := "butler"
+	contextName := "butler"
+	userName := saName
+
+	kubeconfig := clientcmdapi.NewConfig()
+	kubeconfig.Clusters[clusterName] = &clientcmdapi.Cluster{
+		Server:                   m.config.Host,
+		CertificateAuthorityData: m.config.CAData,
+	}
+	// If no CA data but a CA file is set, reference it
+	if len(kubeconfig.Clusters[clusterName].CertificateAuthorityData) == 0 && m.config.CAFile != "" {
+		kubeconfig.Clusters[clusterName].CertificateAuthority = m.config.CAFile
+	}
+
+	kubeconfig.AuthInfos[userName] = &clientcmdapi.AuthInfo{
+		Token: token,
+	}
+
+	kubeconfig.Contexts[contextName] = &clientcmdapi.Context{
+		Cluster:  clusterName,
+		AuthInfo: userName,
+	}
+	kubeconfig.CurrentContext = contextName
+
+	return clientcmd.Write(*kubeconfig)
+}
+
+// CleanupStaleSAs deletes CLI ServiceAccounts whose last-login annotation is
+// older than maxAge.
+func (m *CLIServiceAccountManager) CleanupStaleSAs(ctx context.Context, maxAge time.Duration) error {
+	saList, err := m.clientset.CoreV1().ServiceAccounts(m.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: CLIUserLabel + "=true",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list CLI service accounts: %w", err)
+	}
+
+	cutoff := time.Now().Add(-maxAge)
+	for _, sa := range saList.Items {
+		lastLogin := sa.Annotations[CLILastLoginAnnotation]
+		if lastLogin == "" {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, lastLogin)
+		if err != nil {
+			m.logger.Warn("Invalid last-login annotation", "sa", sa.Name, "value", lastLogin)
+			continue
+		}
+		if t.Before(cutoff) {
+			m.logger.Info("Cleaning up stale CLI service account", "name", sa.Name, "lastLogin", lastLogin)
+
+			// Delete associated RoleBindings
+			email := sa.Annotations[CLIEmailAnnotation]
+			if email != "" {
+				rbs, listErr := m.clientset.RbacV1().RoleBindings("").List(ctx, metav1.ListOptions{
+					LabelSelector: CLIUserLabel + "=true",
+				})
+				if listErr == nil {
+					for _, rb := range rbs.Items {
+						if rb.Annotations[CLIEmailAnnotation] == email {
+							_ = m.clientset.RbacV1().RoleBindings(rb.Namespace).Delete(ctx, rb.Name, metav1.DeleteOptions{})
+						}
+					}
+				}
+
+				// Delete ClusterRoleBinding
+				crbName := sa.Name + "-platform-admin"
+				_ = m.clientset.RbacV1().ClusterRoleBindings().Delete(ctx, crbName, metav1.DeleteOptions{})
+			}
+
+			if delErr := m.clientset.CoreV1().ServiceAccounts(m.namespace).Delete(ctx, sa.Name, metav1.DeleteOptions{}); delErr != nil {
+				m.logger.Warn("Failed to delete stale service account", "name", sa.Name, "error", delErr)
+			}
+		}
+	}
+
+	return nil
+}
+
+// clusterRoleForTeamRole maps a Butler team role to the corresponding ClusterRole name.
+func clusterRoleForTeamRole(role string) string {
+	switch role {
+	case RoleAdmin:
+		return CLIClusterRoleAdmin
+	case RoleOperator:
+		return CLIClusterRoleOperator
+	default:
+		return CLIClusterRoleViewer
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,11 @@ type CLIAuthConfig struct {
 
 	// DeviceCodeExpiry is how long a device code is valid before it expires.
 	DeviceCodeExpiry time.Duration
+
+	// ExternalAPIURL is the external Kubernetes API server URL used in
+	// kubeconfigs issued to CLI users. Required when the server runs
+	// in-cluster since the in-cluster service IP is not reachable externally.
+	ExternalAPIURL string
 }
 
 // ServerConfig holds general server configuration.
@@ -147,6 +152,7 @@ func Load() *Config {
 			RefreshExpiry:    getDurationEnv("BUTLER_CLI_REFRESH_EXPIRY", 7*24*time.Hour),
 			SACleanupTTL:     getDurationEnv("BUTLER_CLI_SA_TTL", 30*24*time.Hour),
 			DeviceCodeExpiry: getDurationEnv("BUTLER_CLI_DEVICE_CODE_EXPIRY", 15*time.Minute),
+			ExternalAPIURL:  getEnv("BUTLER_CLI_EXTERNAL_API_URL", ""),
 		},
 		TenantNamespace: getEnv("BUTLER_TENANT_NAMESPACE", "butler-tenants"),
 		SystemNamespace: getEnv("BUTLER_SYSTEM_NAMESPACE", "butler-system"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,9 +27,28 @@ type Config struct {
 	Server          ServerConfig
 	Auth            AuthConfig
 	OIDC            OIDCConfig
+	CLIAuth         CLIAuthConfig
 	TenantNamespace string
 	SystemNamespace string
 	FrontendURL     string // For dev mode when frontend runs separately
+}
+
+// CLIAuthConfig holds configuration for the CLI device flow authentication.
+type CLIAuthConfig struct {
+	// Enabled controls whether CLI device flow auth endpoints are active.
+	Enabled bool
+
+	// TokenExpiry is the lifetime of SA tokens issued to CLI users.
+	TokenExpiry time.Duration
+
+	// RefreshExpiry is the lifetime of refresh tokens issued to CLI users.
+	RefreshExpiry time.Duration
+
+	// SACleanupTTL is how long unused CLI ServiceAccounts are kept before deletion.
+	SACleanupTTL time.Duration
+
+	// DeviceCodeExpiry is how long a device code is valid before it expires.
+	DeviceCodeExpiry time.Duration
 }
 
 // ServerConfig holds general server configuration.
@@ -121,6 +140,13 @@ func Load() *Config {
 			EmailClaim:               getEnv("BUTLER_OIDC_EMAIL_CLAIM", "email"),
 			GoogleServiceAccountJSON: getEnv("GOOGLE_SERVICE_ACCOUNT_JSON", ""),
 			GoogleAdminEmail:         getEnv("GOOGLE_ADMIN_EMAIL", ""),
+		},
+		CLIAuth: CLIAuthConfig{
+			Enabled:          getBoolEnv("BUTLER_CLI_AUTH_ENABLED", true),
+			TokenExpiry:      getDurationEnv("BUTLER_CLI_TOKEN_EXPIRY", 24*time.Hour),
+			RefreshExpiry:    getDurationEnv("BUTLER_CLI_REFRESH_EXPIRY", 7*24*time.Hour),
+			SACleanupTTL:     getDurationEnv("BUTLER_CLI_SA_TTL", 30*24*time.Hour),
+			DeviceCodeExpiry: getDurationEnv("BUTLER_CLI_DEVICE_CODE_EXPIRY", 15*time.Minute),
 		},
 		TenantNamespace: getEnv("BUTLER_TENANT_NAMESPACE", "butler-tenants"),
 		SystemNamespace: getEnv("BUTLER_SYSTEM_NAMESPACE", "butler-system"),


### PR DESCRIPTION
## Summary

Server-side implementation of ADR-016: CLI authentication via OAuth Device Flow.

### New files
- `internal/auth/device.go` + `device_test.go` -- Device code store with TTL, user code generation, refresh token management (rotate-on-use)
- `internal/auth/serviceaccount.go` -- Per-user SA lifecycle, RoleBinding management per team, TokenRequest API tokens, kubeconfig builder, stale SA cleanup
- `internal/api/handlers/auth_device.go` -- Five HTTP handlers for the device flow

### Endpoints
| Method | Path | Auth | Purpose |
|--------|------|------|---------|
| POST | /api/auth/cli/device | Public | Initiate device flow |
| POST | /api/auth/cli/token | Public | CLI polls for approval |
| POST | /api/auth/cli/verify | Public | Validate user code |
| POST | /api/auth/cli/approve | Session | Browser approves device |
| POST | /api/auth/cli/refresh | Public | Silent token refresh |

### Config
- `BUTLER_CLI_AUTH_ENABLED` (default: true)
- `BUTLER_CLI_TOKEN_EXPIRY` (default: 24h)
- `BUTLER_CLI_REFRESH_EXPIRY` (default: 7 days)
- `BUTLER_CLI_SA_TTL` (default: 30 days)
- `BUTLER_CLI_DEVICE_CODE_EXPIRY` (default: 15 minutes)

### Dependencies
- Requires butler-crds 0.12.0 (ClusterRoles: butler-charts#54)

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./internal/auth/` passes (20 subtests)
- [x] No AI-isms
- [ ] E2E: deploy to butler-beta with ClusterRoles, test full device flow