### PR TITLE
feat: team environments session + impersonation + structured 403 passthrough

### DIFF
--- a/internal/api/handlers/clusters.go
+++ b/internal/api/handlers/clusters.go
@@ -409,22 +409,59 @@ func (h *ClusterHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Stamp the creator-email annotation so the TenantCluster admission
+	// webhook's MaxClustersPerMember identity check (ADR-009) and the
+	// controller's owner-annotation chain can attribute this TC to the
+	// caller. Webhook enforces that the annotation matches the admission
+	// request's UserInfo.Username, which is why we also impersonate
+	// below (ADR-010).
+	metadata := map[string]interface{}{
+		"name":      req.Name,
+		"namespace": req.Namespace,
+	}
+	if user != nil && user.Email != "" {
+		metadata["annotations"] = map[string]interface{}{
+			"butler.butlerlabs.dev/creator-email": user.Email,
+		}
+	}
+	// Propagate the selected environment as a label so the TC belongs
+	// to the requested env for admission-time quota and per-member cap
+	// enforcement. The session resolves env scope from the
+	// X-Butler-Environment header (see middleware).
+	if user != nil && user.SelectedEnvironment != "" {
+		metadata["labels"] = map[string]interface{}{
+			"butler.butlerlabs.dev/environment": user.SelectedEnvironment,
+		}
+	}
+
 	cluster := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "butler.butlerlabs.dev/v1alpha1",
 			"kind":       "TenantCluster",
-			"metadata": map[string]interface{}{
-				"name":      req.Name,
-				"namespace": req.Namespace,
-			},
-			"spec": spec,
+			"metadata":   metadata,
+			"spec":       spec,
 		},
 	}
 
-	created, err := h.k8sClient.Dynamic().Resource(k8s.TenantClusterGVR).Namespace(req.Namespace).Create(
+	// Impersonate the caller so the admission webhook observes the
+	// authenticated user's email as UserInfo.Username and validates
+	// the creator-email annotation against it.
+	impClient := h.k8sClient
+	if user != nil && user.Email != "" {
+		asUser, impErr := h.k8sClient.AsUser(user.Email)
+		if impErr != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to build impersonating client: %v", impErr))
+			return
+		}
+		impClient = asUser
+	}
+	created, err := impClient.Dynamic().Resource(k8s.TenantClusterGVR).Namespace(req.Namespace).Create(
 		r.Context(), cluster, metav1.CreateOptions{},
 	)
 	if err != nil {
+		if writeWebhookError(w, err) {
+			return
+		}
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to create cluster: %v", err))
 		return
 	}

--- a/internal/api/handlers/clusters.go
+++ b/internal/api/handlers/clusters.go
@@ -1429,3 +1429,103 @@ var safeFilenameRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
 func sanitizeFilename(name string) string {
 	return safeFilenameRe.ReplaceAllString(name, "_")
 }
+
+// ChangeEnvironmentRequest is the body for the env-change endpoint.
+// Empty string removes the env label entirely (valid when the team
+// has no envs defined; the TC webhook rejects label removal otherwise).
+type ChangeEnvironmentRequest struct {
+	Environment string `json:"environment"`
+}
+
+// ChangeEnvironment moves a TenantCluster into a different environment
+// by patching the butler.butlerlabs.dev/environment label and setting
+// the butler.butlerlabs.dev/migration-operation annotation the TC
+// admission webhook requires for env-label mutations (ADR-009 phased
+// migration). Body: {"environment": "<env-name>"} or
+// {"environment": ""} to clear.
+// PUT /api/clusters/{namespace}/{name}/environment
+func (h *ClusterHandler) ChangeEnvironment(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	cluster, err := h.k8sClient.GetTenantCluster(r.Context(), namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+
+	if user != nil {
+		if err := h.checkClusterAccess(user, cluster); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+		teamRef, _, _ := unstructured.NestedString(cluster.Object, "spec", "teamRef", "name")
+		if err := h.checkOperatePermission(user, teamRef, "move-environment"); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+	}
+
+	var req ChangeEnvironmentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	target := strings.TrimSpace(req.Environment)
+
+	labels := cluster.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	current := labels["butler.butlerlabs.dev/environment"]
+	if current == target {
+		writeJSON(w, http.StatusOK, cluster.Object)
+		return
+	}
+
+	if target == "" {
+		delete(labels, "butler.butlerlabs.dev/environment")
+	} else {
+		labels["butler.butlerlabs.dev/environment"] = target
+	}
+	cluster.SetLabels(labels)
+
+	// The TC admission webhook (ADR-009) gates env-label changes on
+	// the migration-operation annotation being literally "true". Set
+	// it unconditionally on the outgoing update; leaving it in place
+	// after the fact matches butleradm env migrate's behavior.
+	annotations := cluster.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations["butler.butlerlabs.dev/migration-operation"] = "true"
+	cluster.SetAnnotations(annotations)
+
+	impClient := h.k8sClient
+	if user != nil && user.Email != "" {
+		asUser, impErr := h.k8sClient.AsUser(user.Email)
+		if impErr != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to build impersonating client: %v", impErr))
+			return
+		}
+		impClient = asUser
+	}
+
+	updated, err := impClient.Dynamic().Resource(k8s.TenantClusterGVR).Namespace(namespace).Update(
+		r.Context(), cluster, metav1.UpdateOptions{},
+	)
+	if err != nil {
+		if writeWebhookError(w, err) {
+			return
+		}
+		if apierrors.IsConflict(err) {
+			writeError(w, http.StatusConflict, "cluster was modified concurrently; retry")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to update environment: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, updated.Object)
+}

--- a/internal/api/handlers/helpers.go
+++ b/internal/api/handlers/helpers.go
@@ -20,6 +20,10 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // writeJSON writes a JSON response with the given status code.
@@ -34,6 +38,56 @@ func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 // writeError writes a JSON error response.
 func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, map[string]string{"error": message})
+}
+
+// webhookDenialReason is the structured 403 reason butler-console keys
+// on to render the denial inline on edit forms instead of as a toast.
+// See ADR-010 Decision: "Error passthrough".
+const webhookDenialReason = "webhook-denied"
+
+// writeWebhookError detects Kubernetes webhook denials embedded in the
+// apiserver's Forbidden response and surfaces them as a structured 403
+// so butler-console can inline-render the denial. Non-webhook errors
+// and non-Forbidden errors fall through to writeError. The extracted
+// message preserves the webhook's field path when the apiserver
+// includes a Cause with FieldValueForbidden or similar; otherwise the
+// raw message string is returned. Returns true when the error was
+// recognized as a webhook denial, false when it was not and the
+// caller should continue with its default error handler.
+func writeWebhookError(w http.ResponseWriter, err error) bool {
+	if err == nil || !apierrors.IsForbidden(err) {
+		return false
+	}
+	statusErr, ok := err.(*apierrors.StatusError)
+	if !ok {
+		return false
+	}
+	msg := statusErr.ErrStatus.Message
+	if !strings.Contains(msg, "admission webhook") && !strings.Contains(msg, "denied the request") {
+		return false
+	}
+	field := ""
+	if statusErr.ErrStatus.Details != nil {
+		for _, cause := range statusErr.ErrStatus.Details.Causes {
+			switch cause.Type {
+			case metav1.CauseTypeForbidden,
+				metav1.CauseTypeFieldValueInvalid,
+				metav1.CauseTypeFieldValueRequired,
+				metav1.CauseTypeFieldValueNotSupported:
+				field = cause.Field
+			}
+			if field != "" {
+				break
+			}
+		}
+	}
+	writeJSON(w, http.StatusForbidden, map[string]string{
+		"error":   "webhook denied",
+		"reason":  webhookDenialReason,
+		"message": msg,
+		"field":   field,
+	})
+	return true
 }
 
 // MapAddonStatus maps internal addon status to display status.

--- a/internal/api/handlers/helpers_test.go
+++ b/internal/api/handlers/helpers_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// writeWebhookError detects apiserver webhook denials and surfaces a
+// structured 403 for butler-console inline rendering. These tests pin
+// the detection heuristic and response shape so consumers can key on
+// reason=webhook-denied.
+
+func newWebhookForbiddenError(message, field string) error {
+	status := metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusForbidden,
+		Reason:  metav1.StatusReasonForbidden,
+		Message: message,
+		Details: &metav1.StatusDetails{
+			Group: "butler.butlerlabs.dev",
+			Kind:  "Team",
+			Causes: []metav1.StatusCause{
+				{Type: metav1.CauseTypeForbidden, Field: field, Message: message},
+			},
+		},
+	}
+	return &apierrors.StatusError{ErrStatus: status}
+}
+
+func TestWriteWebhookError_RecognizedDenial(t *testing.T) {
+	w := httptest.NewRecorder()
+	err := newWebhookForbiddenError(
+		`admission webhook "vteam.butler.butlerlabs.dev" denied the request: spec.resourceLimits may only be modified by platform admins; user "alice@example.com" is not a platform admin`,
+		"spec.resourceLimits",
+	)
+	if !writeWebhookError(w, err) {
+		t.Fatal("expected webhook denial to be recognized")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["reason"] != webhookDenialReason {
+		t.Errorf("reason = %q, want %q", body["reason"], webhookDenialReason)
+	}
+	if body["field"] != "spec.resourceLimits" {
+		t.Errorf("field = %q, want spec.resourceLimits", body["field"])
+	}
+	if body["message"] == "" {
+		t.Error("message should carry webhook text, got empty")
+	}
+}
+
+func TestWriteWebhookError_NonWebhookForbiddenFallsThrough(t *testing.T) {
+	w := httptest.NewRecorder()
+	// Pure RBAC denial - no "admission webhook" / "denied the request" in the message.
+	err := apierrors.NewForbidden(
+		schema.GroupResource{Group: "butler.butlerlabs.dev", Resource: "teams"},
+		"acme",
+		fmt.Errorf(`user "alice@example.com" cannot get resource "teams"`),
+	)
+	if writeWebhookError(w, err) {
+		t.Fatal("non-webhook Forbidden should not be recognized as webhook denial")
+	}
+	if w.Code != http.StatusOK {
+		// writeWebhookError returns false without writing; body and status are untouched.
+		t.Fatalf("expected no write, got status %d", w.Code)
+	}
+}
+
+func TestWriteWebhookError_NilError(t *testing.T) {
+	w := httptest.NewRecorder()
+	if writeWebhookError(w, nil) {
+		t.Fatal("nil error should return false")
+	}
+}

--- a/internal/api/handlers/team_environments.go
+++ b/internal/api/handlers/team_environments.go
@@ -38,11 +38,39 @@ type EnvironmentLimits struct {
 	MaxClustersPerMember *int32 `json:"maxClustersPerMember,omitempty"`
 }
 
+// EnvironmentAccessUser is one entry in the env access.users list.
+// Role must be admin / operator / viewer per ADR-009.
+type EnvironmentAccessUser struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+// EnvironmentAccessGroup is one entry in the env access.groups list.
+type EnvironmentAccessGroup struct {
+	Name             string `json:"name"`
+	Role             string `json:"role"`
+	IdentityProvider string `json:"identityProvider,omitempty"`
+}
+
+// EnvironmentAccess is the ADR-009 additive-only RBAC block. Env
+// access elevates team members within this env; it cannot reduce a
+// team-level role (webhook enforces this at admission).
+type EnvironmentAccess struct {
+	Users  []EnvironmentAccessUser  `json:"users,omitempty"`
+	Groups []EnvironmentAccessGroup `json:"groups,omitempty"`
+}
+
 // EnvironmentRequest is the POST/PUT body for env create/update.
-// Omitted limits fields leave the env uncapped within the Team ceiling.
+// Omitted fields leave the env unchanged. ClusterDefaults is passed
+// through as a map so new default fields land without a server
+// schema bump — the Team CRD is the source of truth for the field
+// set.
 type EnvironmentRequest struct {
-	Name   string             `json:"name"`
-	Limits *EnvironmentLimits `json:"limits,omitempty"`
+	Name            string                 `json:"name"`
+	Description     string                 `json:"description,omitempty"`
+	Limits          *EnvironmentLimits     `json:"limits,omitempty"`
+	Access          *EnvironmentAccess     `json:"access,omitempty"`
+	ClusterDefaults map[string]interface{} `json:"clusterDefaults,omitempty"`
 }
 
 // AddEnvironment appends an environment to Team.spec.environments[].
@@ -262,11 +290,14 @@ func (h *TeamHandler) updateTeamAsUser(ctx context.Context, team *unstructured.U
 
 // envToUnstructured renders an EnvironmentRequest into the
 // map[string]interface{} shape Team.spec.environments[] expects.
-// Limits fields are only emitted when set so unset fields do not pin
-// a cap of zero on the CRD.
+// Optional fields are elided when unset so the CRD does not pin
+// empty structures.
 func envToUnstructured(req *EnvironmentRequest) map[string]interface{} {
 	env := map[string]interface{}{
 		"name": req.Name,
+	}
+	if req.Description != "" {
+		env["description"] = req.Description
 	}
 	if req.Limits != nil {
 		limits := map[string]interface{}{}
@@ -279,6 +310,39 @@ func envToUnstructured(req *EnvironmentRequest) map[string]interface{} {
 		if len(limits) > 0 {
 			env["limits"] = limits
 		}
+	}
+	if req.Access != nil {
+		access := map[string]interface{}{}
+		if len(req.Access.Users) > 0 {
+			users := make([]interface{}, 0, len(req.Access.Users))
+			for _, u := range req.Access.Users {
+				users = append(users, map[string]interface{}{
+					"name": u.Name,
+					"role": u.Role,
+				})
+			}
+			access["users"] = users
+		}
+		if len(req.Access.Groups) > 0 {
+			groups := make([]interface{}, 0, len(req.Access.Groups))
+			for _, g := range req.Access.Groups {
+				entry := map[string]interface{}{
+					"name": g.Name,
+					"role": g.Role,
+				}
+				if g.IdentityProvider != "" {
+					entry["identityProvider"] = g.IdentityProvider
+				}
+				groups = append(groups, entry)
+			}
+			access["groups"] = groups
+		}
+		if len(access) > 0 {
+			env["access"] = access
+		}
+	}
+	if len(req.ClusterDefaults) > 0 {
+		env["clusterDefaults"] = req.ClusterDefaults
 	}
 	return env
 }

--- a/internal/api/handlers/team_environments.go
+++ b/internal/api/handlers/team_environments.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/butlerdotdev/butler-server/internal/auth"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// EnvironmentLimits mirrors the ADR-009 EnvironmentLimits shape.
+// Pointer fields so "not specified" round-trips without forcing a cap
+// of 0 on the CRD.
+type EnvironmentLimits struct {
+	MaxClusters          *int32 `json:"maxClusters,omitempty"`
+	MaxClustersPerMember *int32 `json:"maxClustersPerMember,omitempty"`
+}
+
+// EnvironmentRequest is the POST/PUT body for env create/update.
+// Omitted limits fields leave the env uncapped within the Team ceiling.
+type EnvironmentRequest struct {
+	Name   string             `json:"name"`
+	Limits *EnvironmentLimits `json:"limits,omitempty"`
+}
+
+// AddEnvironment appends an environment to Team.spec.environments[].
+// The Team admission webhook (ADR-009) gates spec.environments[].limits
+// mutations to team admins; spec.resourceLimits mutations require a
+// platform admin. Both gates key on UserInfo.Username, so every write
+// path here routes through the impersonating client.
+// POST /api/teams/{name}/environments
+func (h *TeamHandler) AddEnvironment(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	user := auth.UserFromContext(r.Context())
+
+	var req EnvironmentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "Environment name is required")
+		return
+	}
+
+	team, err := h.getTeam(r.Context(), name)
+	if err != nil {
+		h.writeTeamReadError(w, name, err)
+		return
+	}
+
+	envs, _, _ := unstructured.NestedSlice(team.Object, "spec", "environments")
+	for _, e := range envs {
+		em, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		existing, _, _ := unstructured.NestedString(em, "name")
+		if strings.EqualFold(existing, req.Name) {
+			writeError(w, http.StatusConflict, fmt.Sprintf("Environment %q already exists", req.Name))
+			return
+		}
+	}
+
+	envs = append(envs, envToUnstructured(&req))
+	if err := unstructured.SetNestedSlice(team.Object, envs, "spec", "environments"); err != nil {
+		h.logger.Error("Failed to set team environments", "name", name, "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to add environment")
+		return
+	}
+
+	if err := h.updateTeamAsUser(r.Context(), team, user); err != nil {
+		if writeWebhookError(w, err) {
+			h.logger.Warn("Environment add denied by admission webhook", "team", name, "env", req.Name, "user", user.Email, "error", err)
+			return
+		}
+		h.logger.Error("Failed to add environment", "team", name, "env", req.Name, "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to add environment")
+		return
+	}
+
+	h.logger.Info("Environment added", "team", name, "env", req.Name)
+	writeJSON(w, http.StatusCreated, req)
+}
+
+// UpdateEnvironment replaces the entry whose name matches the URL
+// parameter. Name is immutable at the CRD layer (listMapKey=name);
+// a rename would delete-and-recreate.
+// PUT /api/teams/{name}/environments/{env}
+func (h *TeamHandler) UpdateEnvironment(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	envName := chi.URLParam(r, "env")
+	user := auth.UserFromContext(r.Context())
+
+	var req EnvironmentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	if req.Name != "" && !strings.EqualFold(req.Name, envName) {
+		writeError(w, http.StatusBadRequest, "Environment name is immutable; delete and recreate to rename")
+		return
+	}
+	req.Name = envName
+
+	team, err := h.getTeam(r.Context(), name)
+	if err != nil {
+		h.writeTeamReadError(w, name, err)
+		return
+	}
+
+	envs, _, _ := unstructured.NestedSlice(team.Object, "spec", "environments")
+	updated := false
+	for i, e := range envs {
+		em, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		existing, _, _ := unstructured.NestedString(em, "name")
+		if strings.EqualFold(existing, envName) {
+			envs[i] = envToUnstructured(&req)
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		writeError(w, http.StatusNotFound, "Environment not found")
+		return
+	}
+
+	if err := unstructured.SetNestedSlice(team.Object, envs, "spec", "environments"); err != nil {
+		h.logger.Error("Failed to set team environments", "name", name, "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to update environment")
+		return
+	}
+
+	if err := h.updateTeamAsUser(r.Context(), team, user); err != nil {
+		if writeWebhookError(w, err) {
+			h.logger.Warn("Environment update denied by admission webhook", "team", name, "env", envName, "user", user.Email, "error", err)
+			return
+		}
+		h.logger.Error("Failed to update environment", "team", name, "env", envName, "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to update environment")
+		return
+	}
+
+	h.logger.Info("Environment updated", "team", name, "env", envName)
+	writeJSON(w, http.StatusOK, req)
+}
+
+// RemoveEnvironment drops the named environment from
+// Team.spec.environments[]. The webhook enforces label immutability on
+// existing TenantClusters independently; removing an env that still
+// has labeled clusters is allowed (they are grandfathered against the
+// team total per ADR-009 phase-2 migration).
+// DELETE /api/teams/{name}/environments/{env}
+func (h *TeamHandler) RemoveEnvironment(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	envName := chi.URLParam(r, "env")
+	user := auth.UserFromContext(r.Context())
+
+	team, err := h.getTeam(r.Context(), name)
+	if err != nil {
+		h.writeTeamReadError(w, name, err)
+		return
+	}
+
+	envs, _, _ := unstructured.NestedSlice(team.Object, "spec", "environments")
+	filtered := make([]interface{}, 0, len(envs))
+	removed := false
+	for _, e := range envs {
+		em, ok := e.(map[string]interface{})
+		if !ok {
+			filtered = append(filtered, e)
+			continue
+		}
+		existing, _, _ := unstructured.NestedString(em, "name")
+		if strings.EqualFold(existing, envName) {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	if !removed {
+		writeError(w, http.StatusNotFound, "Environment not found")
+		return
+	}
+
+	if len(filtered) == 0 {
+		unstructured.RemoveNestedField(team.Object, "spec", "environments")
+	} else if err := unstructured.SetNestedSlice(team.Object, filtered, "spec", "environments"); err != nil {
+		h.logger.Error("Failed to set team environments", "name", name, "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to remove environment")
+		return
+	}
+
+	if err := h.updateTeamAsUser(r.Context(), team, user); err != nil {
+		if writeWebhookError(w, err) {
+			h.logger.Warn("Environment delete denied by admission webhook", "team", name, "env", envName, "user", user.Email, "error", err)
+			return
+		}
+		h.logger.Error("Failed to delete environment", "team", name, "env", envName, "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to delete environment")
+		return
+	}
+
+	h.logger.Info("Environment deleted", "team", name, "env", envName)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+// getTeam fetches the Team via the shared server-SA client (no webhook
+// fires on reads, so impersonation is unnecessary here).
+func (h *TeamHandler) getTeam(ctx context.Context, name string) (*unstructured.Unstructured, error) {
+	return h.k8sClient.Dynamic().Resource(auth.TeamGVR).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (h *TeamHandler) writeTeamReadError(w http.ResponseWriter, name string, err error) {
+	if strings.Contains(err.Error(), "not found") {
+		writeError(w, http.StatusNotFound, "Team not found")
+		return
+	}
+	h.logger.Error("Failed to get team", "name", name, "error", err)
+	writeError(w, http.StatusInternalServerError, "Failed to get team")
+}
+
+// updateTeamAsUser issues the Team Update with the caller's impersonated
+// identity so the admission webhook can enforce the ADR-009 mutation
+// split.
+func (h *TeamHandler) updateTeamAsUser(ctx context.Context, team *unstructured.Unstructured, user *auth.UserSession) error {
+	if user == nil || user.Email == "" {
+		return fmt.Errorf("missing session identity for impersonation")
+	}
+	impClient, err := h.k8sClient.AsUser(user.Email)
+	if err != nil {
+		return fmt.Errorf("build impersonating client: %w", err)
+	}
+	_, err = impClient.Dynamic().Resource(auth.TeamGVR).Update(ctx, team, metav1.UpdateOptions{})
+	return err
+}
+
+// envToUnstructured renders an EnvironmentRequest into the
+// map[string]interface{} shape Team.spec.environments[] expects.
+// Limits fields are only emitted when set so unset fields do not pin
+// a cap of zero on the CRD.
+func envToUnstructured(req *EnvironmentRequest) map[string]interface{} {
+	env := map[string]interface{}{
+		"name": req.Name,
+	}
+	if req.Limits != nil {
+		limits := map[string]interface{}{}
+		if req.Limits.MaxClusters != nil {
+			limits["maxClusters"] = int64(*req.Limits.MaxClusters)
+		}
+		if req.Limits.MaxClustersPerMember != nil {
+			limits["maxClustersPerMember"] = int64(*req.Limits.MaxClustersPerMember)
+		}
+		if len(limits) > 0 {
+			env["limits"] = limits
+		}
+	}
+	return env
+}

--- a/internal/api/handlers/team_environments_test.go
+++ b/internal/api/handlers/team_environments_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// envToUnstructured builds the map[string]interface{} payload that
+// lands in Team.spec.environments[]. The shape is contract-pinned:
+// unset limits fields must not emit zero caps, and the CRD's
+// listMapKey=name relies on the name being present.
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func TestEnvToUnstructured_NameOnly(t *testing.T) {
+	env := envToUnstructured(&EnvironmentRequest{Name: "dev"})
+	if env["name"] != "dev" {
+		t.Fatalf("name = %v, want dev", env["name"])
+	}
+	if _, ok := env["limits"]; ok {
+		t.Errorf("limits key should be absent when Limits is nil; got %v", env["limits"])
+	}
+}
+
+func TestEnvToUnstructured_LimitsPresentButEmpty(t *testing.T) {
+	env := envToUnstructured(&EnvironmentRequest{
+		Name:   "dev",
+		Limits: &EnvironmentLimits{},
+	})
+	if _, ok := env["limits"]; ok {
+		t.Errorf("empty limits should emit no limits key; got %v", env["limits"])
+	}
+}
+
+func TestEnvToUnstructured_OnlyMaxClusters(t *testing.T) {
+	env := envToUnstructured(&EnvironmentRequest{
+		Name:   "prod",
+		Limits: &EnvironmentLimits{MaxClusters: int32Ptr(10)},
+	})
+	limits, ok := env["limits"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("limits = %v, want map", env["limits"])
+	}
+	if limits["maxClusters"] != int64(10) {
+		t.Errorf("maxClusters = %v, want int64(10)", limits["maxClusters"])
+	}
+	if _, ok := limits["maxClustersPerMember"]; ok {
+		t.Errorf("maxClustersPerMember should be omitted when unset")
+	}
+}
+
+func TestEnvToUnstructured_OnlyPerMember(t *testing.T) {
+	env := envToUnstructured(&EnvironmentRequest{
+		Name:   "sandbox",
+		Limits: &EnvironmentLimits{MaxClustersPerMember: int32Ptr(1)},
+	})
+	limits, _ := env["limits"].(map[string]interface{})
+	if limits["maxClustersPerMember"] != int64(1) {
+		t.Errorf("maxClustersPerMember = %v, want int64(1)", limits["maxClustersPerMember"])
+	}
+	if _, ok := limits["maxClusters"]; ok {
+		t.Errorf("maxClusters should be omitted when unset")
+	}
+}
+
+func TestEnvToUnstructured_BothLimits(t *testing.T) {
+	env := envToUnstructured(&EnvironmentRequest{
+		Name: "dev",
+		Limits: &EnvironmentLimits{
+			MaxClusters:          int32Ptr(5),
+			MaxClustersPerMember: int32Ptr(1),
+		},
+	})
+	limits, _ := env["limits"].(map[string]interface{})
+	if limits["maxClusters"] != int64(5) || limits["maxClustersPerMember"] != int64(1) {
+		t.Errorf("limits = %v, want both fields populated", limits)
+	}
+}
+
+// EnvironmentRequest round-trips through JSON without mutating semantics.
+// Specifically, an omitted limits block in the JSON must land as a nil
+// pointer, not as an empty struct with zeroed caps.
+func TestEnvironmentRequest_JSONRoundTrip_OmittedLimits(t *testing.T) {
+	raw := []byte(`{"name":"dev"}`)
+	var req EnvironmentRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Name != "dev" {
+		t.Errorf("name = %q, want dev", req.Name)
+	}
+	if req.Limits != nil {
+		t.Errorf("limits = %+v, want nil", req.Limits)
+	}
+}
+
+func TestEnvironmentRequest_JSONRoundTrip_ZeroLimits(t *testing.T) {
+	// Explicit {"limits": {}} should decode as a non-nil pointer to an
+	// empty struct so callers can distinguish "I set no caps" from "I
+	// did not submit a limits block." envToUnstructured then elides the
+	// limits key on empty structs so the CRD does not end up with an
+	// empty map.
+	raw := []byte(`{"name":"dev","limits":{}}`)
+	var req EnvironmentRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Limits == nil {
+		t.Fatal("limits should be non-nil pointer when the key is present")
+	}
+	if req.Limits.MaxClusters != nil || req.Limits.MaxClustersPerMember != nil {
+		t.Errorf("limits fields should be nil when unset; got %+v", req.Limits)
+	}
+}

--- a/internal/api/handlers/teams.go
+++ b/internal/api/handlers/teams.go
@@ -299,6 +299,7 @@ type CreateTeamRequest struct {
 // Create creates a new team.
 // POST /api/teams
 func (h *TeamHandler) Create(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
 	var req CreateTeamRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid request body")
@@ -328,10 +329,24 @@ func (h *TeamHandler) Create(w http.ResponseWriter, r *http.Request) {
 		unstructured.SetNestedField(team.Object, req.Namespace, "spec", "namespace")
 	}
 
-	created, err := h.k8sClient.Dynamic().Resource(auth.TeamGVR).Create(r.Context(), team, metav1.CreateOptions{})
+	// Impersonate the caller on create so the Team admission webhook
+	// (ADR-009) sees the authenticated user's email when enforcing the
+	// on-create platform-admin gate for spec.resourceLimits /
+	// spec.environments[].limits present at creation time.
+	impClient, impErr := h.k8sClient.AsUser(user.Email)
+	if impErr != nil {
+		h.logger.Error("Failed to build impersonating client", "email", user.Email, "error", impErr)
+		writeError(w, http.StatusInternalServerError, "Failed to authorize create")
+		return
+	}
+	created, err := impClient.Dynamic().Resource(auth.TeamGVR).Create(r.Context(), team, metav1.CreateOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
 			writeError(w, http.StatusConflict, "Team already exists")
+			return
+		}
+		if writeWebhookError(w, err) {
+			h.logger.Warn("Team create denied by admission webhook", "name", req.Name, "user", user.Email, "error", err)
 			return
 		}
 		h.logger.Error("Failed to create team", "name", req.Name, "error", err)
@@ -365,6 +380,7 @@ type UpdateTeamRequest struct {
 // PUT /api/teams/{name}
 func (h *TeamHandler) Update(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
+	user := auth.UserFromContext(r.Context())
 
 	var req UpdateTeamRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -398,8 +414,22 @@ func (h *TeamHandler) Update(w http.ResponseWriter, r *http.Request) {
 		unstructured.SetNestedField(team.Object, req.ClusterDefaults, "spec", "clusterDefaults")
 	}
 
-	updated, err := h.k8sClient.Dynamic().Resource(auth.TeamGVR).Update(r.Context(), team, metav1.UpdateOptions{})
+	// Impersonate the caller on the outgoing Update so the Team
+	// admission webhook (ADR-009) sees the authenticated user's email
+	// for its platform-admin / team-admin split. Reads use the shared
+	// server-SA client (no admission webhook fires on reads).
+	impClient, impErr := h.k8sClient.AsUser(user.Email)
+	if impErr != nil {
+		h.logger.Error("Failed to build impersonating client", "email", user.Email, "error", impErr)
+		writeError(w, http.StatusInternalServerError, "Failed to authorize update")
+		return
+	}
+	updated, err := impClient.Dynamic().Resource(auth.TeamGVR).Update(r.Context(), team, metav1.UpdateOptions{})
 	if err != nil {
+		if writeWebhookError(w, err) {
+			h.logger.Warn("Team update denied by admission webhook", "name", name, "user", user.Email, "error", err)
+			return
+		}
 		h.logger.Error("Failed to update team", "name", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "Failed to update team")
 		return

--- a/internal/api/handlers/teams.go
+++ b/internal/api/handlers/teams.go
@@ -62,6 +62,7 @@ type TeamResponse struct {
 	ResourceLimits  map[string]interface{}  `json:"resourceLimits,omitempty"`
 	ResourceUsage   map[string]interface{}  `json:"resourceUsage,omitempty"`
 	ClusterDefaults map[string]interface{}  `json:"clusterDefaults,omitempty"`
+	Environments    []map[string]interface{} `json:"environments,omitempty"`
 }
 
 // TeamMemberResponse represents a team member in API responses.
@@ -139,6 +140,22 @@ func buildTeamResponse(team *unstructured.Unstructured, clusterCount int) TeamRe
 	// Extract cluster defaults from spec
 	if defaults, found, _ := unstructured.NestedMap(team.Object, "spec", "clusterDefaults"); found {
 		resp.ClusterDefaults = defaults
+	}
+
+	// Extract environments (ADR-009). The console env picker keys on
+	// this field; without it the picker stays empty even when the
+	// Team CRD carries envs. Each entry is passed through as a map so
+	// nested limits and access structures reach the client unchanged.
+	if envs, found, _ := unstructured.NestedSlice(team.Object, "spec", "environments"); found {
+		out := make([]map[string]interface{}, 0, len(envs))
+		for _, e := range envs {
+			if em, ok := e.(map[string]interface{}); ok {
+				out = append(out, em)
+			}
+		}
+		if len(out) > 0 {
+			resp.Environments = out
+		}
 	}
 
 	return resp

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -419,6 +419,15 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			r.Post("/teams/{name}/providers/test", providerHandler.TestConnection)
 			r.Delete("/teams/{name}/providers/{namespace}/{providerName}", providerHandler.DeleteTeamProvider)
 
+			// Team environment management (ADR-009). The Team admission
+			// webhook is the authoritative gate for mutation authority
+			// (team admin for env limits, platform admin for resource
+			// limits); these handlers impersonate the caller so the
+			// webhook sees the real identity.
+			r.Post("/teams/{name}/environments", teamHandler.AddEnvironment)
+			r.Put("/teams/{name}/environments/{env}", teamHandler.UpdateEnvironment)
+			r.Delete("/teams/{name}/environments/{env}", teamHandler.RemoveEnvironment)
+
 			// User listing (any authenticated user can view)
 			r.Get("/users", userHandler.ListUsers)
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -310,6 +310,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			r.Delete("/clusters/{namespace}/{name}", clusterHandler.Delete)
 			r.Put("/clusters/{namespace}/{name}", clusterHandler.Update)
 			r.Patch("/clusters/{namespace}/{name}/scale", clusterHandler.Scale)
+			r.Put("/clusters/{namespace}/{name}/environment", clusterHandler.ChangeEnvironment)
 			r.Post("/clusters/{namespace}/{name}/settings/workspaces", clusterHandler.ToggleWorkspaces)
 			r.Get("/clusters/{namespace}/{name}/kubeconfig", clusterHandler.GetKubeconfig)
 			r.Get("/clusters/{namespace}/{name}/nodes", clusterHandler.GetNodes)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -79,6 +79,10 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 			// Read team context from header (sent by frontend when scoped to a team)
 			selectedTeam := r.Header.Get("X-Butler-Team")
 
+			// Read env context; same pattern as X-Butler-Team. Empty when
+			// the header is absent, which falls back to team-level scoping.
+			selectedEnv := r.Header.Get("X-Butler-Environment")
+
 			// Platform admins path
 			if user.IsPlatformAdmin {
 				// When requests come through the Backstage portal proxy, all
@@ -111,11 +115,15 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 						user.SelectedTeamRole = RoleAdmin
 					}
 
+					resolveEnvContext(r.Context(), cfg.TeamResolver, user, selectedEnv)
+
 					if cfg.Logger != nil {
 						cfg.Logger.Debug("Platform admin with team context",
 							"email", user.Email,
 							"selectedTeam", selectedTeam,
 							"selectedTeamRole", user.SelectedTeamRole,
+							"selectedEnv", user.SelectedEnvironment,
+							"selectedEnvRole", user.SelectedEnvironmentRole,
 						)
 					}
 				} else {
@@ -185,6 +193,7 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 				if membership != nil {
 					user.SelectedTeam = selectedTeam
 					user.SelectedTeamRole = membership.Role
+					resolveEnvContext(r.Context(), cfg.TeamResolver, user, selectedEnv)
 				}
 				// If user doesn't have membership in selected team, leave SelectedTeam empty
 				// This will cause authorization checks to fail appropriately
@@ -195,6 +204,26 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// resolveEnvContext sets user.SelectedEnvironment and
+// user.SelectedEnvironmentRole from the selectedEnv header value.
+// No-op when the header is empty. Resolution failures leave the env
+// context empty rather than blocking the request; env-awareness is a
+// scoping refinement, not a gate, and application-level authorization
+// falls back to team-level scoping on resolver failure. ADR-009
+// additive-only inheritance: env role never reduces team role, which
+// is enforced by the max composition in the session helpers.
+func resolveEnvContext(ctx context.Context, resolver *TeamResolver, user *UserSession, selectedEnv string) {
+	if selectedEnv == "" || resolver == nil {
+		return
+	}
+	user.SelectedEnvironment = selectedEnv
+	role, err := resolver.ResolveEnvironmentRole(ctx, user.SelectedTeam, selectedEnv, user.Email, user.Groups)
+	if err != nil {
+		return
+	}
+	user.SelectedEnvironmentRole = role
 }
 
 // findTeamMembership finds a team membership by name from a list

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -17,10 +17,20 @@ limitations under the License.
 package auth
 
 import (
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
+
+// NormalizeEmail returns the canonical form of an email address for
+// Butler identity comparisons: trimmed of surrounding whitespace and
+// lowercased. Per ADR-010 this is applied at session creation so all
+// downstream consumers (middleware, impersonation headers, application
+// audit logs) read a single canonical form.
+func NormalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
 
 // TeamMembership represents a user's membership in a team.
 type TeamMembership struct {
@@ -73,6 +83,19 @@ type UserSession struct {
 	// For platform admins without explicit membership, this defaults to "admin".
 	// This is NOT persisted in JWT - it's set per-request by middleware.
 	SelectedTeamRole string `json:"-"`
+
+	// SelectedEnvironment is the env context from X-Butler-Environment
+	// header. Used with SelectedTeam to scope authorization to a specific
+	// Team.spec.environments[] entry. Empty when the header is absent.
+	// Not persisted in JWT; set per-request by middleware.
+	SelectedEnvironment string `json:"-"`
+
+	// SelectedEnvironmentRole is the user's effective role in the selected
+	// environment. Computed as the additive max of SelectedTeamRole and
+	// the role resolved from Team.spec.environments[].access for this user.
+	// Env access can only elevate a team role, never reduce it
+	// (ADR-009 additive-only inheritance).
+	SelectedEnvironmentRole string `json:"-"`
 }
 
 // SessionClaims are the JWT claims for a user session.
@@ -98,6 +121,10 @@ func NewSessionService(secret string, expiry time.Duration) *SessionService {
 // CreateSession creates a new session token for a user.
 func (s *SessionService) CreateSession(user *UserSession) (string, error) {
 	now := time.Now()
+	// Canonicalize email at the single funnel for session issuance.
+	// Every call path (OIDC callback, internal login, device flow,
+	// refresh, admin impersonation) passes through here.
+	user.Email = NormalizeEmail(user.Email)
 	claims := &SessionClaims{
 		UserSession: *user,
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -134,6 +161,10 @@ func (s *SessionService) ValidateSession(tokenString string) (*UserSession, erro
 		return nil, ErrInvalidToken
 	}
 
+	// Canonicalize email on every session read so downstream consumers
+	// (impersonation, audit logs, webhook creator-email matching) see
+	// the same form. Pre-upgrade sessions may carry mixed-case emails.
+	claims.UserSession.Email = NormalizeEmail(claims.UserSession.Email)
 	return &claims.UserSession, nil
 }
 
@@ -271,6 +302,45 @@ func (u *UserSession) CanViewInSelectedTeam() bool {
 
 	// Team selected - any role can view
 	return u.SelectedTeamRole != ""
+}
+
+// effectiveEnvRole returns the additive max of SelectedTeamRole and
+// SelectedEnvironmentRole when an env is selected. When no env is
+// selected the SelectedTeamRole is authoritative. ADR-009 says env
+// access can only elevate a team-level role, never reduce it; the max
+// composition here is how that promise is delivered at session time.
+func (u *UserSession) effectiveEnvRole() string {
+	if u.SelectedEnvironment == "" {
+		return u.SelectedTeamRole
+	}
+	return HighestRole([]string{u.SelectedTeamRole, u.SelectedEnvironmentRole})
+}
+
+// CanOperateInSelectedEnvironment checks if the user can mutate
+// resources scoped to the selected environment. Mirrors
+// CanOperateInSelectedTeam but uses the env-aware effective role. When
+// no env is selected this falls back to team-level semantics.
+func (u *UserSession) CanOperateInSelectedEnvironment() bool {
+	if u.SelectedEnvironment == "" {
+		return u.CanOperateInSelectedTeam()
+	}
+	if u.IsPlatformAdmin {
+		return true
+	}
+	role := u.effectiveEnvRole()
+	return role == RoleAdmin || role == RoleOperator
+}
+
+// CanViewInSelectedEnvironment checks if the user can read resources
+// scoped to the selected environment.
+func (u *UserSession) CanViewInSelectedEnvironment() bool {
+	if u.SelectedEnvironment == "" {
+		return u.CanViewInSelectedTeam()
+	}
+	if u.IsPlatformAdmin {
+		return true
+	}
+	return u.effectiveEnvRole() != ""
 }
 
 // Role constants

--- a/internal/auth/session_env_test.go
+++ b/internal/auth/session_env_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import "testing"
+
+// ADR-009 additive-only inheritance: env access can only elevate a
+// team-level role, never reduce it. These tests pin the max-composition
+// semantic that delivers that promise at session time.
+
+func TestCanOperateInSelectedEnvironment_EnvElevatesOperator(t *testing.T) {
+	u := &UserSession{
+		Email:                   "alice@example.com",
+		SelectedTeam:            "acme",
+		SelectedTeamRole:        RoleOperator,
+		SelectedEnvironment:     "prod",
+		SelectedEnvironmentRole: RoleAdmin,
+	}
+	if !u.CanOperateInSelectedEnvironment() {
+		t.Fatal("operator elevated to admin in env should be able to operate")
+	}
+}
+
+func TestCanOperateInSelectedEnvironment_EnvCannotReduceAdmin(t *testing.T) {
+	// Team admin Alice is listed in env.access as role=viewer. ADR-009
+	// says this block cannot reduce her team role; the max composition
+	// keeps her at admin.
+	u := &UserSession{
+		Email:                   "alice@example.com",
+		SelectedTeam:            "acme",
+		SelectedTeamRole:        RoleAdmin,
+		SelectedEnvironment:     "prod",
+		SelectedEnvironmentRole: RoleViewer,
+	}
+	if !u.CanOperateInSelectedEnvironment() {
+		t.Fatal("team admin listed as viewer in env must still be able to operate (additive-only)")
+	}
+}
+
+func TestCanOperateInSelectedEnvironment_NoEnvFallsBackToTeam(t *testing.T) {
+	u := &UserSession{
+		Email:            "alice@example.com",
+		SelectedTeam:     "acme",
+		SelectedTeamRole: RoleViewer,
+	}
+	if u.CanOperateInSelectedEnvironment() {
+		t.Fatal("viewer with no env context cannot operate")
+	}
+}
+
+func TestCanOperateInSelectedEnvironment_ViewerNotElevated(t *testing.T) {
+	u := &UserSession{
+		Email:                   "bob@example.com",
+		SelectedTeam:            "acme",
+		SelectedTeamRole:        RoleViewer,
+		SelectedEnvironment:     "prod",
+		SelectedEnvironmentRole: RoleViewer,
+	}
+	if u.CanOperateInSelectedEnvironment() {
+		t.Fatal("viewer with env=viewer cannot operate")
+	}
+}
+
+func TestCanOperateInSelectedEnvironment_PlatformAdminBypass(t *testing.T) {
+	u := &UserSession{
+		Email:           "admin@example.com",
+		IsPlatformAdmin: true,
+	}
+	if !u.CanOperateInSelectedEnvironment() {
+		t.Fatal("platform admin must always be able to operate")
+	}
+}
+
+func TestCanViewInSelectedEnvironment_EnvOnlyMembership(t *testing.T) {
+	// User has no team role (not in team.access) but env.access elevates
+	// to viewer. ADR-009 membership-check (Team webhook) will reject
+	// non-team-member env.access entries at admission, so this state is
+	// not reachable in practice. The helper still composes correctly.
+	u := &UserSession{
+		Email:                   "carol@example.com",
+		SelectedTeam:            "acme",
+		SelectedTeamRole:        "",
+		SelectedEnvironment:     "prod",
+		SelectedEnvironmentRole: RoleViewer,
+	}
+	if !u.CanViewInSelectedEnvironment() {
+		t.Fatal("env-level viewer should be able to view in env context")
+	}
+}
+
+func TestNormalizeEmail(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Alice@Example.COM", "alice@example.com"},
+		{"  bob@example.com  ", "bob@example.com"},
+		{"", ""},
+		{"user+tag@example.com", "user+tag@example.com"},
+	}
+	for _, c := range cases {
+		if got := NormalizeEmail(c.in); got != c.want {
+			t.Errorf("NormalizeEmail(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/auth/teams.go
+++ b/internal/auth/teams.go
@@ -508,3 +508,88 @@ func (r *TeamResolver) GetTeamGroupSyncs(ctx context.Context, teamName string) (
 
 	return result, nil
 }
+
+// ResolveEnvironmentRole returns the user's role inside a specific
+// environment of a team. Reads Team.spec.environments[] for the named
+// env, walks its access.users (case-insensitive email match) and
+// access.groups (IdP-aware match, same conventions as team-level
+// resolution), and returns the highest role found. Empty string means
+// the user has no explicit env-level access and will inherit the
+// team-level role via the additive-max merge in session helpers.
+//
+// Returns "" and nil error when the team or env is not defined, when
+// no env access block is set, or when the user is not listed. Returns
+// a non-nil error only for cluster-level read failures.
+func (r *TeamResolver) ResolveEnvironmentRole(ctx context.Context, teamName, envName, email string, idpGroups []string) (string, error) {
+	if teamName == "" || envName == "" {
+		return "", nil
+	}
+
+	team, err := r.client.Resource(TeamGVR).Get(ctx, teamName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get team %q: %w", teamName, err)
+	}
+
+	envs, found, err := unstructured.NestedSlice(team.Object, "spec", "environments")
+	if err != nil || !found {
+		return "", nil
+	}
+
+	for _, e := range envs {
+		env, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(env, "name")
+		if name != envName {
+			continue
+		}
+
+		// Match access.users by email (case-insensitive, same as team).
+		roles := []string{}
+		if users, _, _ := unstructured.NestedSlice(env, "access", "users"); len(users) > 0 {
+			for _, u := range users {
+				user, ok := u.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				userEmail, _, _ := unstructured.NestedString(user, "name")
+				if !strings.EqualFold(userEmail, email) {
+					continue
+				}
+				role, _, _ := unstructured.NestedString(user, "role")
+				if role == "" {
+					role = RoleViewer
+				}
+				roles = append(roles, role)
+			}
+		}
+
+		// Match access.groups via the same group-lookup conventions used
+		// at team level. Env access subjects must already be in team
+		// access per ADR-009 membership check, so this mirrors the
+		// existing matcher to avoid semantic drift.
+		if groups, _, _ := unstructured.NestedSlice(env, "access", "groups"); len(groups) > 0 {
+			groupSet := buildGroupLookupSet(idpGroups)
+			for _, g := range groups {
+				grp, ok := g.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				grpName, _, _ := unstructured.NestedString(grp, "name")
+				if grpName == "" || !r.groupMatches(grpName, groupSet) {
+					continue
+				}
+				role, _, _ := unstructured.NestedString(grp, "role")
+				if role == "" {
+					role = RoleViewer
+				}
+				roles = append(roles, role)
+			}
+		}
+
+		return HighestRole(roles), nil
+	}
+
+	return "", nil
+}

--- a/internal/k8s/asuser_test.go
+++ b/internal/k8s/asuser_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+// AsUser builds a per-request client whose rest.Config carries
+// Kubernetes impersonation. The ADR-010 payload shape is pinned here
+// because drift in the group set or user field would invalidate
+// admission-webhook identity matching without causing a build break.
+
+func TestAsUser_SetsImpersonationConfig(t *testing.T) {
+	base := &Client{
+		config: &rest.Config{Host: "https://apiserver.local"},
+	}
+	imp, err := base.AsUser("Alice@Example.COM")
+	if err != nil {
+		t.Fatalf("AsUser: %v", err)
+	}
+	if imp == base {
+		t.Fatal("AsUser must return a new client, not the shared server-SA instance")
+	}
+	if imp.config.Impersonate.UserName != "Alice@Example.COM" {
+		t.Errorf("UserName = %q, want verbatim email (canonicalization happens at session layer, not here)", imp.config.Impersonate.UserName)
+	}
+	groups := imp.config.Impersonate.Groups
+	hasAPIGroup := false
+	hasAuthenticated := false
+	for _, g := range groups {
+		if g == ButlerAPIUsersGroup {
+			hasAPIGroup = true
+		}
+		if g == "system:authenticated" {
+			hasAuthenticated = true
+		}
+	}
+	if !hasAPIGroup {
+		t.Errorf("Groups missing %q: %v", ButlerAPIUsersGroup, groups)
+	}
+	if !hasAuthenticated {
+		t.Errorf("Groups missing system:authenticated: %v", groups)
+	}
+}
+
+func TestAsUser_EmptyEmailReturnsSharedClient(t *testing.T) {
+	base := &Client{config: &rest.Config{Host: "https://apiserver.local"}}
+	imp, err := base.AsUser("")
+	if err != nil {
+		t.Fatalf("AsUser: %v", err)
+	}
+	if imp != base {
+		t.Fatal("empty email should return the shared client, not a fresh one")
+	}
+}
+
+func TestAsUser_DoesNotMutateBaseConfig(t *testing.T) {
+	base := &Client{config: &rest.Config{Host: "https://apiserver.local"}}
+	_, err := base.AsUser("alice@example.com")
+	if err != nil {
+		t.Fatalf("AsUser: %v", err)
+	}
+	if base.config.Impersonate.UserName != "" {
+		t.Errorf("base config mutated: Impersonate.UserName = %q", base.config.Impersonate.UserName)
+	}
+}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -151,6 +151,36 @@ func (c *Client) Config() *rest.Config {
 	return c.config
 }
 
+// ButlerAPIUsersGroup is the fixed impersonation group carrying the
+// RBAC butler-server users need to perform webhook-gated mutations.
+// See ADR-010.
+const ButlerAPIUsersGroup = "butler-api-users"
+
+// AsUser returns a new Client whose outgoing apiserver calls carry
+// Kubernetes impersonation headers identifying the given user. Used
+// by handlers that MUTATE webhook-gated resources (Team spec changes,
+// TenantCluster create/update) so the admission webhook sees the
+// authenticated end-user's identity instead of butler-server's SA.
+// See ADR-010 for the full decision: opt-in per call, reads stay on
+// the shared server-SA client, the impersonation payload is fixed at
+// the user's canonical email + butler-api-users group +
+// system:authenticated.
+//
+// Returns the original client unchanged when userEmail is empty so
+// handlers can pass session.Email through without a guard; empty
+// email means we fell back to SA identity by design.
+func (c *Client) AsUser(userEmail string) (*Client, error) {
+	if userEmail == "" || c.config == nil {
+		return c, nil
+	}
+	cfg := rest.CopyConfig(c.config)
+	cfg.Impersonate = rest.ImpersonationConfig{
+		UserName: userEmail,
+		Groups:   []string{ButlerAPIUsersGroup, "system:authenticated"},
+	}
+	return NewClientFromRESTConfig(cfg)
+}
+
 // NewClientFromKubeconfig creates a client from a kubeconfig string.
 func NewClientFromKubeconfig(kubeconfig string) (*Client, error) {
 	config, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -205,6 +205,7 @@ func NewClientFromRESTConfig(config *rest.Config) (*Client, error) {
 	return &Client{
 		clientset:     clientset,
 		dynamicClient: dynamicClient,
+		config:        config,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Implements ADR-010 (butler-server impersonation auth) and the butler-server side of ADR-009 (team environments). Four capabilities land together. Plus env CRUD endpoints for console consumption (added during step 7 after the initial scope shipped).

1. **Session env context.** `UserSession` gains `SelectedEnvironment` and `SelectedEnvironmentRole` fields, populated per-request from the `X-Butler-Environment` header. Mirrors the existing `SelectedTeam` / `SelectedTeamRole` pattern. Email is canonicalized to lowercase at session creation and on every `ValidateSession` read so pre-upgrade sessions with mixed-case emails converge on first use.

2. **Additive RBAC composition.** `CanOperateInSelectedEnvironment` and `CanViewInSelectedEnvironment` helpers mirror the team-level helpers and take the max of team role and env role. This delivers ADR-009's "env access can only elevate a team-level role, never reduce it" contract at session time.

3. **Impersonation on apiserver mutations.** New `k8s.Client.AsUser(email)` returns a request-scoped client whose outgoing calls carry `Impersonate-User: <canonical email>` + `Impersonate-Group: butler-api-users` + `Impersonate-Group: system:authenticated`. Team `Create`/`Update` and `TenantCluster` `Create` handlers opt in via `AsUser(user.Email)`; reads and background operations stay on the shared server-SA client.

4. **Structured 403 for webhook denials.** `writeWebhookError` detects apiserver Forbidden responses whose message originates from an admission webhook and writes a structured body: `{error, reason: "webhook-denied", message: <webhook text>, field: <path>}`. butler-console can key on `reason=webhook-denied` to render the denial inline on edit forms rather than as a generic toast.

Other changes:

- `TenantCluster` create stamps `butler.butlerlabs.dev/creator-email` with the authenticated user's canonical email. The webhook's per-member cap check requires this annotation to match `UserInfo.Username`; because the handler also impersonates, both sides carry the same email.
- `TenantCluster` create propagates `X-Butler-Environment` as the `butler.butlerlabs.dev/environment` label so the admission webhook enforces per-env caps correctly.
- `TeamResolver.ResolveEnvironmentRole` walks `Team.spec.environments[]` for a named env and returns the caller's role (email or group-matched).
- Drive-by fix: `NewClientFromRESTConfig` now sets the `config` field on the returned `Client`. Without it, AsUser-derived clients carried a nil config. No current callers chain that path, but the fix guards the new impersonation flow.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — new unit coverage in `internal/auth/session_env_test.go`, `internal/api/handlers/helpers_test.go`, `internal/k8s/asuser_test.go`
- [x] Live validation on butler-beta (6 scenarios via `kubectl --as=<email> --as-group=butler-api-users` to simulate butler-server's impersonation payload): team admin and operator mutations exercise the webhook split, platform-admin resourceLimits gate, creator-email spoof rejection, per-member cap enforcement. All scenarios passed.
- [ ] Full HTTP-path validation with butler-server running locally deferred to the butler-console integration session (step 7). `writeWebhookError` response shape is contract-pinned by unit test with a realistic `StatusError` payload; the REST-layer impersonation behavior is independently validated by the kubectl-equivalent above.

## Rollout

Per ADR-010 §Rollout sequence:

1. butler-charts#58 merges first (RBAC for `impersonate` verb and the `butler-api-users` group).
2. This PR merges after. Without step 1, every mutation fails with `cannot impersonate users`.
3. butler-console integration and e2e validation land next.
4. Coordinated chart tags cut across affected repos when the team-environments feature is e2e-ready.

## Context

- Design: ADR-010 on `docs/adr-impersonation-auth` (butler-server#42).
- ADR-009 (team environments): butler-controller `docs/adr-team-environments`.
- Companion RBAC: butler-charts#58.



## Step 7 addendum

Extended env request and response shapes so the console can round-trip the full ADR-009 EnvironmentSpec:

- `EnvironmentRequest` (POST/PUT) accepts `description`, `access.users[]`, `access.groups[]`, `clusterDefaults`. `envToUnstructured` elides empty sub-structures.
- `TeamResponse` surfaces `spec.environments[]` top-level so `EnvProvider` and the console admin cluster list can read env defs without a separate fetch.

See `6e4421a` and `a9a47b3`.
