### PR TITLE
fix(gitops): load CA from file when CAData empty in in-cluster kubeconfig synthesis

### DIFF
--- a/internal/k8s/gitops.go
+++ b/internal/k8s/gitops.go
@@ -215,6 +215,19 @@ func (c *Client) GetManagementKubeconfig() ([]byte, error) {
 // work from the pod's mounted ServiceAccount identity. Extracted from the
 // rest.InClusterConfig caller so tests can inject a synthetic config.
 func kubeconfigFromRESTConfig(cfg *rest.Config) ([]byte, error) {
+	// rest.InClusterConfig() returns a *rest.Config where TLSClientConfig.CAFile
+	// points at /var/run/secrets/kubernetes.io/serviceaccount/ca.crt and CAData
+	// is empty — the file's bytes are read lazily by the HTTP transport. Clients
+	// that parse this kubeconfig build their own transport and need the CA
+	// inline, so the synthesis must promote CAFile to CAData bytes here.
+	caData := cfg.CAData
+	if len(caData) == 0 && cfg.CAFile != "" {
+		data, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA file %s: %w", cfg.CAFile, err)
+		}
+		caData = data
+	}
 	kc := clientcmdapi.Config{
 		APIVersion:     "v1",
 		Kind:           "Config",
@@ -222,7 +235,7 @@ func kubeconfigFromRESTConfig(cfg *rest.Config) ([]byte, error) {
 		Clusters: map[string]*clientcmdapi.Cluster{
 			"in-cluster": {
 				Server:                   cfg.Host,
-				CertificateAuthorityData: cfg.CAData,
+				CertificateAuthorityData: caData,
 			},
 		},
 		Contexts: map[string]*clientcmdapi.Context{

--- a/internal/k8s/gitops_test.go
+++ b/internal/k8s/gitops_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package k8s
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -72,6 +74,66 @@ func TestKubeconfigFromRESTConfig_RoundTrip(t *testing.T) {
 	}
 	if authInfo.Token != cfg.BearerToken {
 		t.Errorf("token did not round-trip")
+	}
+}
+
+func TestKubeconfigFromRESTConfig_LoadsCAFromFile(t *testing.T) {
+	// rest.InClusterConfig() returns CAFile set + CAData empty. The synthesis
+	// must promote the file bytes into CertificateAuthorityData so downstream
+	// consumers that build their own transport can verify the apiserver cert.
+	// Regression guard for the v0.7.1 hotfix.
+	caBytes := []byte("-----BEGIN CERTIFICATE-----\nMIIBfiletest\n-----END CERTIFICATE-----\n")
+	tmpDir := t.TempDir()
+	caPath := filepath.Join(tmpDir, "ca.crt")
+	if err := os.WriteFile(caPath, caBytes, 0o600); err != nil {
+		t.Fatalf("write test CA file: %v", err)
+	}
+
+	cfg := &rest.Config{
+		Host:        "https://10.96.0.1:443",
+		BearerToken: "sa-token",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAFile: caPath,
+		},
+	}
+
+	data, err := kubeconfigFromRESTConfig(cfg)
+	if err != nil {
+		t.Fatalf("kubeconfigFromRESTConfig: %v", err)
+	}
+
+	apiCfg, err := clientcmd.Load(data)
+	if err != nil {
+		t.Fatalf("emitted bytes do not parse as kubeconfig: %v", err)
+	}
+	cluster := apiCfg.Clusters["in-cluster"]
+	if cluster == nil {
+		t.Fatal("in-cluster cluster missing")
+	}
+	if string(cluster.CertificateAuthorityData) != string(caBytes) {
+		t.Errorf("CertificateAuthorityData = %q, want the CAFile contents %q", cluster.CertificateAuthorityData, caBytes)
+	}
+	if cluster.CertificateAuthority != "" {
+		t.Error("expected CAData only, not a file path reference")
+	}
+}
+
+func TestKubeconfigFromRESTConfig_CAFileMissing(t *testing.T) {
+	// If CAFile is set but unreadable, return an error rather than emitting a
+	// kubeconfig with no CA (which silently reproduces the bug we are fixing).
+	cfg := &rest.Config{
+		Host:        "https://10.96.0.1:443",
+		BearerToken: "sa-token",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAFile: "/tmp/definitely-does-not-exist/ca.crt",
+		},
+	}
+	data, err := kubeconfigFromRESTConfig(cfg)
+	if err == nil {
+		t.Fatalf("expected error when CAFile is missing, got data: %q", data)
+	}
+	if !strings.Contains(err.Error(), "read CA file") {
+		t.Errorf("error = %q, want it to mention CA file", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

Hotfix for v0.7.0's in-cluster kubeconfig synthesis. \`rest.InClusterConfig()\` returns a config with \`TLSClientConfig.CAFile\` set and \`CAData\` empty — the file bytes are loaded lazily by the HTTP transport that \`rest.Config\` builds for its own callers. Consumers that parse the synthesized kubeconfig (Helm release discovery, \`flux bootstrap\`) build a separate transport and need the CA inline.

v0.7.0's \`kubeconfigFromRESTConfig\` was assigning \`cfg.CAData\` unconditionally, so the emitted kubeconfig had no CA and downstream TLS fell back to system trust: \`x509: certificate signed by unknown authority\`.

Fix reads \`cfg.CAFile\` when \`cfg.CAData\` is empty, promotes the bytes to \`CertificateAuthorityData\`, and returns an error when the file cannot be read (rather than silently emitting a kubeconfig with no CA).

## Test plan

- [x] \`go vet\` clean
- [x] New test \`TestKubeconfigFromRESTConfig_LoadsCAFromFile\`: CAFile set + CAData empty produces \`CertificateAuthorityData\` matching file contents
- [x] New test \`TestKubeconfigFromRESTConfig_CAFileMissing\`: missing CAFile returns a clear error, no silent empty-CA output
- [x] Existing \`TestKubeconfigFromRESTConfig_RoundTrip\` still green (CAData-populated path unchanged)
- [ ] Post-deploy: Management GitOps tab on butler-beta returns Helm releases (validated by session after tag + Flux rollout)

## Fix target

Ships as butler-server v0.7.1 after merge. No ADR, chart, or RBAC changes.