### PR TITLE
fix(gitops): populate Flux Repository/Branch/Path in detectFlux

### DIFF
--- a/internal/gitops/discovery.go
+++ b/internal/gitops/discovery.go
@@ -24,10 +24,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -83,6 +86,11 @@ func DiscoverHelmReleases(ctx context.Context, kubeconfig []byte, addonDefs []bu
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	dynClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
 	addonLookup := buildAddonLookup(addonDefs)
@@ -142,13 +150,13 @@ func DiscoverHelmReleases(ctx context.Context, kubeconfig []byte, addonDefs []bu
 		}
 	}
 
-	result.GitOpsEngine = detectGitOpsEngine(ctx, clientset)
+	result.GitOpsEngine = detectGitOpsEngine(ctx, clientset, dynClient)
 
 	return result, nil
 }
 
-func detectGitOpsEngine(ctx context.Context, clientset *kubernetes.Clientset) *GitOpsEngineStatus {
-	if fluxStatus := detectFlux(ctx, clientset); fluxStatus != nil {
+func detectGitOpsEngine(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface) *GitOpsEngineStatus {
+	if fluxStatus := detectFlux(ctx, clientset, dynClient); fluxStatus != nil {
 		return fluxStatus
 	}
 
@@ -159,7 +167,7 @@ func detectGitOpsEngine(ctx context.Context, clientset *kubernetes.Clientset) *G
 	return nil
 }
 
-func detectFlux(ctx context.Context, clientset *kubernetes.Clientset) *GitOpsEngineStatus {
+func detectFlux(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface) *GitOpsEngineStatus {
 	deployments, err := clientset.AppsV1().Deployments("flux-system").List(ctx, metav1.ListOptions{})
 	if err != nil || len(deployments.Items) == 0 {
 		return nil
@@ -181,20 +189,103 @@ func detectFlux(ctx context.Context, clientset *kubernetes.Clientset) *GitOpsEng
 		}
 	}
 
-	if len(readyComponents) >= 2 {
-		return &GitOpsEngineStatus{
-			Provider:   "flux",
-			Installed:  true,
-			Ready:      len(readyComponents) >= 3,
-			Version:    version,
-			Components: readyComponents,
+	if len(readyComponents) < 2 {
+		return nil
+	}
+
+	status := &GitOpsEngineStatus{
+		Provider:   "flux",
+		Installed:  true,
+		Ready:      len(readyComponents) >= 3,
+		Version:    version,
+		Components: readyComponents,
+	}
+
+	// Populate Repository/Branch/Path from the Flux bootstrap CRs when
+	// readable. Failures here must not regress Flux detection itself:
+	// logged at debug level and the engine status still returns with
+	// Installed=true so the UI shows GitOps is enabled even if the
+	// bootstrap-config lookup partial-fails.
+	enrichFluxFromBootstrapCRs(ctx, dynClient, status)
+
+	return status
+}
+
+// enrichFluxFromBootstrapCRs reads the Flux-created GitRepository and
+// Kustomization in flux-system to populate Repository/Branch/Path on
+// status. `flux bootstrap` names both "flux-system" so the lookup is
+// deterministic; falls back to the first GitRepository in the namespace
+// for out-of-band installs that chose a different name.
+func enrichFluxFromBootstrapCRs(ctx context.Context, dynClient dynamic.Interface, status *GitOpsEngineStatus) {
+	if dynClient == nil {
+		return
+	}
+
+	gitRepoGVR := schema.GroupVersionResource{
+		Group:    "source.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "gitrepositories",
+	}
+	list, err := dynClient.Resource(gitRepoGVR).Namespace("flux-system").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		slog.Debug("flux: list GitRepositories failed", "namespace", "flux-system", "error", err)
+		return
+	}
+	if len(list.Items) == 0 {
+		slog.Debug("flux: no GitRepository in flux-system")
+		return
+	}
+
+	gitRepo := list.Items[0]
+	for i := range list.Items {
+		if list.Items[i].GetName() == "flux-system" {
+			gitRepo = list.Items[i]
+			break
 		}
 	}
 
-	return nil
+	spec, ok := gitRepo.Object["spec"].(map[string]interface{})
+	if !ok {
+		slog.Debug("flux: GitRepository spec missing or malformed", "name", gitRepo.GetName())
+		return
+	}
+	if rawURL, ok := spec["url"].(string); ok && rawURL != "" {
+		if owner, repo, err := ParseRepoURL(rawURL); err == nil {
+			status.Repository = fmt.Sprintf("%s/%s", owner, repo)
+		} else {
+			status.Repository = rawURL
+		}
+	}
+	// Branch is the primary ref; fall back to tag then commit so the UI
+	// surfaces whatever pin is actually driving reconciliation.
+	if ref, ok := spec["ref"].(map[string]interface{}); ok {
+		if b, ok := ref["branch"].(string); ok && b != "" {
+			status.Branch = b
+		} else if t, ok := ref["tag"].(string); ok && t != "" {
+			status.Branch = t
+		} else if c, ok := ref["commit"].(string); ok && c != "" {
+			status.Branch = c
+		}
+	}
+
+	kustomizationGVR := schema.GroupVersionResource{
+		Group:    "kustomize.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "kustomizations",
+	}
+	ks, err := dynClient.Resource(kustomizationGVR).Namespace("flux-system").Get(ctx, "flux-system", metav1.GetOptions{})
+	if err != nil {
+		slog.Debug("flux: get Kustomization/flux-system failed", "error", err)
+		return
+	}
+	if ksSpec, ok := ks.Object["spec"].(map[string]interface{}); ok {
+		if p, ok := ksSpec["path"].(string); ok {
+			status.Path = p
+		}
+	}
 }
 
-func detectArgoCD(ctx context.Context, clientset *kubernetes.Clientset) *GitOpsEngineStatus {
+func detectArgoCD(ctx context.Context, clientset kubernetes.Interface) *GitOpsEngineStatus {
 	argoComponents := []string{
 		"argocd-server",
 		"argocd-repo-server",

--- a/internal/gitops/discovery_test.go
+++ b/internal/gitops/discovery_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// detectFlux must populate Repository/Branch/Path from the Flux-created
+// GitRepository and Kustomization CRs so the Management GitOps export
+// modal pre-fills correctly. Before v0.7.2 those fields were stitched
+// in by the handler after calling GetFluxGitRepositoryConfig separately;
+// the unified path lets the UI rely on a single source.
+
+func fluxDeployments() []runtime.Object {
+	mk := func(name string) *appsv1.Deployment {
+		d := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "flux-system"},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: name, Image: "ghcr.io/fluxcd/" + name + ":v2.3.0"}},
+					},
+				},
+			},
+			Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+		}
+		return d
+	}
+	return []runtime.Object{
+		mk("source-controller"),
+		mk("kustomize-controller"),
+		mk("helm-controller"),
+	}
+}
+
+func gitRepositoryUnstructured(name, url, branch, tag, commit string) *unstructured.Unstructured {
+	spec := map[string]interface{}{
+		"url":      url,
+		"interval": "1m",
+	}
+	ref := map[string]interface{}{}
+	if branch != "" {
+		ref["branch"] = branch
+	}
+	if tag != "" {
+		ref["tag"] = tag
+	}
+	if commit != "" {
+		ref["commit"] = commit
+	}
+	if len(ref) > 0 {
+		spec["ref"] = ref
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "source.toolkit.fluxcd.io/v1",
+			"kind":       "GitRepository",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "flux-system",
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func kustomizationUnstructured(name, path string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "flux-system",
+			},
+			"spec": map[string]interface{}{
+				"path": path,
+			},
+		},
+	}
+}
+
+func newFakeDynamicClient(objs ...runtime.Object) dynamic.Interface {
+	scheme := runtime.NewScheme()
+	gvrMap := map[schema.GroupVersionResource]string{
+		{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"}: "GitRepositoryList",
+		{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}: "KustomizationList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrMap, objs...)
+}
+
+func TestDetectFlux_PopulatesRepositoryBranchPath(t *testing.T) {
+	clientset := fake.NewSimpleClientset(fluxDeployments()...)
+	dynClient := newFakeDynamicClient(
+		gitRepositoryUnstructured("flux-system", "https://github.com/butlerdotdev/butler-mgmt-live.git", "main", "", ""),
+		kustomizationUnstructured("flux-system", "clusters/management"),
+	)
+
+	status := detectFlux(context.Background(), clientset, dynClient)
+	if status == nil {
+		t.Fatal("expected non-nil GitOpsEngineStatus")
+	}
+	if status.Provider != "flux" || !status.Installed {
+		t.Errorf("provider=%q installed=%v; want flux/true", status.Provider, status.Installed)
+	}
+	if status.Repository != "butlerdotdev/butler-mgmt-live" {
+		t.Errorf("Repository = %q, want %q", status.Repository, "butlerdotdev/butler-mgmt-live")
+	}
+	if status.Branch != "main" {
+		t.Errorf("Branch = %q, want %q", status.Branch, "main")
+	}
+	if status.Path != "clusters/management" {
+		t.Errorf("Path = %q, want %q", status.Path, "clusters/management")
+	}
+}
+
+func TestDetectFlux_RefFallbackToTag(t *testing.T) {
+	clientset := fake.NewSimpleClientset(fluxDeployments()...)
+	dynClient := newFakeDynamicClient(
+		gitRepositoryUnstructured("flux-system", "https://github.com/butlerdotdev/butler-mgmt-live", "", "v1.2.3", ""),
+		kustomizationUnstructured("flux-system", "clusters/management"),
+	)
+
+	status := detectFlux(context.Background(), clientset, dynClient)
+	if status == nil {
+		t.Fatal("expected non-nil GitOpsEngineStatus")
+	}
+	if status.Branch != "v1.2.3" {
+		t.Errorf("Branch = %q, want tag %q (branch-missing-fallback)", status.Branch, "v1.2.3")
+	}
+}
+
+func TestDetectFlux_RefFallbackToCommit(t *testing.T) {
+	clientset := fake.NewSimpleClientset(fluxDeployments()...)
+	dynClient := newFakeDynamicClient(
+		gitRepositoryUnstructured("flux-system", "https://github.com/butlerdotdev/butler-mgmt-live", "", "", "abc1234def"),
+		kustomizationUnstructured("flux-system", "clusters/management"),
+	)
+
+	status := detectFlux(context.Background(), clientset, dynClient)
+	if status == nil {
+		t.Fatal("expected non-nil GitOpsEngineStatus")
+	}
+	if status.Branch != "abc1234def" {
+		t.Errorf("Branch = %q, want commit %q (tag-missing-fallback)", status.Branch, "abc1234def")
+	}
+}
+
+func TestDetectFlux_EnabledEvenWithoutGitRepository(t *testing.T) {
+	// Regression guard: GitRepository read failing or returning nothing
+	// must not regress Flux detection itself. Installed=true should still
+	// flow through so the UI shows GitOps enabled and the operator can
+	// investigate why the bootstrap CRs are missing.
+	clientset := fake.NewSimpleClientset(fluxDeployments()...)
+	dynClient := newFakeDynamicClient()
+
+	status := detectFlux(context.Background(), clientset, dynClient)
+	if status == nil {
+		t.Fatal("expected non-nil GitOpsEngineStatus even without bootstrap CRs")
+	}
+	if !status.Installed {
+		t.Error("Installed = false; want true (detection must survive CR read miss)")
+	}
+	if status.Repository != "" {
+		t.Errorf("Repository = %q, want empty when GitRepository missing", status.Repository)
+	}
+	if status.Branch != "" {
+		t.Errorf("Branch = %q, want empty", status.Branch)
+	}
+	if status.Path != "" {
+		t.Errorf("Path = %q, want empty", status.Path)
+	}
+}
+
+func TestDetectFlux_EnabledWhenGitRepositoryReadErrors(t *testing.T) {
+	// RBAC denial on gitrepositories must not regress Flux detection.
+	// Simulated via a reactor returning Forbidden on list.
+	clientset := fake.NewSimpleClientset(fluxDeployments()...)
+	dynClient := newFakeDynamicClient()
+	fakeDyn := dynClient.(*dynamicfake.FakeDynamicClient)
+	fakeDyn.PrependReactor("list", "gitrepositories", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden")
+	})
+
+	status := detectFlux(context.Background(), clientset, dynClient)
+	if status == nil {
+		t.Fatal("expected non-nil GitOpsEngineStatus even when list errors")
+	}
+	if !status.Installed {
+		t.Error("Installed = false; want true despite list error")
+	}
+	if status.Repository != "" {
+		t.Errorf("Repository = %q, want empty on list error", status.Repository)
+	}
+}
+
+func TestDetectFlux_ReturnsNilWhenFluxAbsent(t *testing.T) {
+	clientset := fake.NewSimpleClientset() // no flux deployments
+	dynClient := newFakeDynamicClient()
+
+	status := detectFlux(context.Background(), clientset, dynClient)
+	if status != nil {
+		t.Errorf("status = %+v, want nil when Flux is not installed", status)
+	}
+}
+
+func TestDetectFlux_FallsBackToFirstGitRepositoryWhenNoneNamedFluxSystem(t *testing.T) {
+	// Out-of-band installs may use a non-default GitRepository name.
+	// The enrichment should still read the first available entry.
+	clientset := fake.NewSimpleClientset(fluxDeployments()...)
+	dynClient := newFakeDynamicClient(
+		gitRepositoryUnstructured("custom-name", "https://github.com/example/repo", "develop", "", ""),
+	)
+
+	status := detectFlux(context.Background(), clientset, dynClient)
+	if status == nil {
+		t.Fatal("expected non-nil GitOpsEngineStatus")
+	}
+	if status.Repository != "example/repo" {
+		t.Errorf("Repository = %q, want %q", status.Repository, "example/repo")
+	}
+	if status.Branch != "develop" {
+		t.Errorf("Branch = %q, want develop", status.Branch)
+	}
+}
+
+var _ kubernetes.Interface = (*fake.Clientset)(nil) // compile-time assertion


### PR DESCRIPTION
## Summary

Management GitOps export modal shows an empty Target Repository dropdown even when Flux is installed and running. Root cause: \`detectFlux\` never populates \`Repository\`, \`Branch\`, \`Path\` on the returned \`GitOpsEngineStatus\`, despite those fields existing on the struct. The UI binds \`configuredRepository={gitopsEngine?.repository}\` and the pre-fill never lands.

## Changes

- Extend \`detectFlux\` in \`internal/gitops/discovery.go\` to read the Flux bootstrap CRs after confirming detection:
  - \`GitRepository\` in \`flux-system\` (prefer \`flux-system\` name, fall back to first)
  - \`Kustomization/flux-system\` in \`flux-system\`
- Fill \`Repository\` (converted to \`owner/repo\` via existing \`ParseRepoURL\`), \`Branch\` (with \`tag\` then \`commit\` fallback when \`branch\` is not set), \`Path\`.
- CR-read failures are logged at debug level and leave the field empty. Flux detection itself still returns \`Installed=true\` so the UI correctly shows GitOps enabled even if the bootstrap-config lookup partial-fails (e.g. RBAC denial on the CRs, bootstrap done with a non-standard name).
- Thread a \`dynamic.Interface\` through \`DiscoverHelmReleases\` -> \`detectGitOpsEngine\` -> \`detectFlux\`; switch clientset parameter from concrete \`*kubernetes.Clientset\` to \`kubernetes.Interface\` so tests can inject the fake client.
- New \`discovery_test.go\` with six cases: happy path, branch-missing fallback to tag, tag-missing fallback to commit, CR absent, list errors, Flux absent, non-standard GitRepository name.

## Required chart RBAC

butler-server needs \`get,list,watch\` on \`gitrepositories.source.toolkit.fluxcd.io\` and \`kustomizations.kustomize.toolkit.fluxcd.io\` cluster-wide (or at minimum in \`flux-system\`). Shipped as a patch bump on the butler-console chart in a companion PR: butlerdotdev/butler-charts#TBD.

## Test plan

- [x] \`CGO_ENABLED=0 go vet ./...\` clean
- [x] \`go test ./internal/gitops/...\` passes (new six cases + existing GitLab suite)
- [ ] Post-merge: tag \`v0.7.2\`, Flux image automation picks up on butler-beta
- [ ] Butler-charts PR merges with RBAC additions, chart tag cut, Flux reconciles on butler-beta
- [ ] Refresh Management GitOps tab on console.beta.butlerlabs.dev, expect Repository / Branch / Path fields pre-filled with live Flux state

Closes #50