### PR TITLE
Bump butler-api to v0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-server
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.12.0
+	github.com/butlerdotdev/butler-api v0.13.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creack/pty v1.1.9
 	github.com/go-chi/chi/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/butlerdotdev/butler-api v0.12.0 h1:vVdFo0gonfebZkc1/5hlxnTGEbyD4WG45ZGpfPtuGX8=
-github.com/butlerdotdev/butler-api v0.12.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.13.0 h1:mnW1YEPD0QG9d2P+kr7DWSs5ViGf5DXSHnVWmE5Cjt8=
+github.com/butlerdotdev/butler-api v0.13.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=


### PR DESCRIPTION
## Context

butler-api v0.13.0 (ADR-014 PR 1) adds `PlatformRole` to `UserSpec`
and `PlatformRoleGroups` to `IdentityProviderSpec`.

## Changes

- Bump `butler-api` from v0.12.0 to v0.13.0

No code changes in this PR. The session model migration (using
`PlatformRole` instead of `IsPlatformAdmin` across 15 files) is
ADR-014 PR 2 scope, which builds on this module bump.

## Test plan

- All tests pass
- Build and vet clean

Refs butlerdotdev/butler-api#33