### PR TITLE
feat: use AddonDefinition.Tier for GitOps export directory placement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-server
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.13.0
+	github.com/butlerdotdev/butler-api v0.14.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creack/pty v1.1.9
 	github.com/go-chi/chi/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/butlerdotdev/butler-api v0.13.0 h1:mnW1YEPD0QG9d2P+kr7DWSs5ViGf5DXSHnVWmE5Cjt8=
-github.com/butlerdotdev/butler-api v0.13.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.14.0 h1:PR6J0eYB7/6Mk5AbPSRSubaNhQZJj1lL2YDdkbVWsKQ=
+github.com/butlerdotdev/butler-api v0.14.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/internal/api/handlers/gitops.go
+++ b/internal/api/handlers/gitops.go
@@ -597,18 +597,14 @@ func (h *GitOpsHandler) ExportAddon(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var targetPath string
-	if addonDef.Spec.Platform {
-		targetPath = fmt.Sprintf("clusters/%s/infrastructure/%s", name, req.AddonName)
-	} else {
-		targetPath = fmt.Sprintf("clusters/%s/apps/%s", name, req.AddonName)
-	}
+	tier := addonDef.GetEffectiveTier()
+	targetPath := fmt.Sprintf("clusters/%s/%s/%s", name, tier, req.AddonName)
 
 	h.logger.Info("Exporting addon to GitOps",
 		"cluster", name,
 		"addon", req.AddonName,
 		"path", targetPath,
-		"platform", addonDef.Spec.Platform,
+		"tier", tier,
 	)
 
 	chartName := addonDef.Spec.Chart.Name
@@ -1723,11 +1719,8 @@ func (h *GitOpsHandler) ExportManagementCatalogAddon(w http.ResponseWriter, r *h
 
 	targetPath := req.TargetPath
 	if targetPath == "" {
-		if addonDef.Spec.Platform {
-			targetPath = fmt.Sprintf("clusters/management/infrastructure/%s", req.AddonName)
-		} else {
-			targetPath = fmt.Sprintf("clusters/management/apps/%s", req.AddonName)
-		}
+		tier := addonDef.GetEffectiveTier()
+		targetPath = fmt.Sprintf("clusters/management/%s/%s", tier, req.AddonName)
 	}
 
 	chartName := addonDef.Spec.Chart.Name

--- a/internal/api/handlers/gitops.go
+++ b/internal/api/handlers/gitops.go
@@ -857,11 +857,7 @@ func (h *GitOpsHandler) ExportRelease(w http.ResponseWriter, r *http.Request) {
 
 	targetPath := req.Path
 	if targetPath == "" {
-		if release.Category == "infrastructure" {
-			targetPath = fmt.Sprintf("clusters/%s/infrastructure/%s", name, release.Name)
-		} else {
-			targetPath = fmt.Sprintf("clusters/%s/apps/%s", name, release.Name)
-		}
+		targetPath = fmt.Sprintf("clusters/%s/%s/%s", name, release.Category, release.Name)
 	} else {
 		if !strings.HasSuffix(targetPath, "/"+release.Name) {
 			targetPath = fmt.Sprintf("%s/%s", targetPath, release.Name)
@@ -1069,13 +1065,7 @@ func (h *GitOpsHandler) ExportAllAddons(w http.ResponseWriter, r *http.Request) 
 			seenNamespaces[release.Namespace] = true
 		}
 
-		var basePath string
-		if release.Category == "infrastructure" {
-			basePath = fmt.Sprintf("clusters/%s/infrastructure", name)
-		} else {
-			basePath = fmt.Sprintf("clusters/%s/apps", name)
-		}
-		targetPath := fmt.Sprintf("%s/%s", basePath, release.Name)
+		targetPath := fmt.Sprintf("clusters/%s/%s/%s", name, release.Category, release.Name)
 
 		for filename, content := range manifests {
 			path := fmt.Sprintf("%s/%s", targetPath, filename)
@@ -1562,11 +1552,7 @@ func (h *GitOpsHandler) ExportManagementAddon(w http.ResponseWriter, r *http.Req
 
 	targetPath := req.Path
 	if targetPath == "" {
-		if release.Category == "infrastructure" {
-			targetPath = fmt.Sprintf("clusters/management/infrastructure/%s", release.Name)
-		} else {
-			targetPath = fmt.Sprintf("clusters/management/apps/%s", release.Name)
-		}
+		targetPath = fmt.Sprintf("clusters/management/%s/%s", release.Category, release.Name)
 	} else {
 		targetPath = fmt.Sprintf("%s/%s", targetPath, release.Name)
 	}
@@ -1940,13 +1926,7 @@ func (h *GitOpsHandler) ExportAllManagementAddons(w http.ResponseWriter, r *http
 			seenNamespaces[release.Namespace] = true
 		}
 
-		var categoryPath string
-		if release.Category == "infrastructure" {
-			categoryPath = fmt.Sprintf("%s/infrastructure", basePath)
-		} else {
-			categoryPath = fmt.Sprintf("%s/apps", basePath)
-		}
-		targetPath := fmt.Sprintf("%s/%s", categoryPath, release.Name)
+		targetPath := fmt.Sprintf("%s/%s/%s", basePath, release.Category, release.Name)
 
 		for filename, content := range manifests {
 			path := fmt.Sprintf("%s/%s", targetPath, filename)

--- a/internal/gitops/discovery.go
+++ b/internal/gitops/discovery.go
@@ -141,7 +141,7 @@ func DiscoverHelmReleases(ctx context.Context, kubeconfig []byte, addonDefs []bu
 			release.AddonDefinition = addonDef.Name
 			release.RepoURL = addonDef.Spec.Chart.Repository
 			release.Platform = addonDef.Spec.Platform
-			release.Category = categoryFromPlatform(addonDef.Spec.Platform)
+			release.Category = addonDef.GetEffectiveTier()
 			result.Matched = append(result.Matched, release)
 		} else {
 			release.Category = "apps"
@@ -471,12 +471,6 @@ func matchAddonDefinition(chartName string, lookup map[string]*butlerv1alpha1.Ad
 	return nil, false
 }
 
-func categoryFromPlatform(platform bool) string {
-	if platform {
-		return "infrastructure"
-	}
-	return "apps"
-}
 
 // Migration types
 

--- a/internal/gitops/discovery.go
+++ b/internal/gitops/discovery.go
@@ -471,7 +471,6 @@ func matchAddonDefinition(chartName string, lookup map[string]*butlerv1alpha1.Ad
 	return nil, false
 }
 
-
 // Migration types
 
 // MigrationRequest defines a request to migrate releases to GitOps.

--- a/internal/gitops/discovery_test.go
+++ b/internal/gitops/discovery_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -254,3 +255,78 @@ func TestDetectFlux_FallsBackToFirstGitRepositoryWhenNoneNamedFluxSystem(t *test
 }
 
 var _ kubernetes.Interface = (*fake.Clientset)(nil) // compile-time assertion
+
+func TestAddonTierToReleasePath(t *testing.T) {
+	layout := DefaultDirectoryLayout("test-cluster")
+
+	tests := []struct {
+		name     string
+		addon    butlerv1alpha1.AddonDefinition
+		wantTier string
+		wantPath string
+	}{
+		{
+			name: "explicit infrastructure tier",
+			addon: butlerv1alpha1.AddonDefinition{
+				Spec: butlerv1alpha1.AddonDefinitionSpec{
+					Tier: butlerv1alpha1.AddonTierInfrastructure,
+				},
+			},
+			wantTier: "infrastructure",
+			wantPath: "infrastructure/sealed-secrets",
+		},
+		{
+			name: "explicit apps tier",
+			addon: butlerv1alpha1.AddonDefinition{
+				Spec: butlerv1alpha1.AddonDefinitionSpec{
+					Tier: butlerv1alpha1.AddonTierApps,
+				},
+			},
+			wantTier: "apps",
+			wantPath: "apps/sealed-secrets",
+		},
+		{
+			name: "explicit tier overrides platform",
+			addon: butlerv1alpha1.AddonDefinition{
+				Spec: butlerv1alpha1.AddonDefinitionSpec{
+					Tier:     butlerv1alpha1.AddonTierApps,
+					Platform: true,
+				},
+			},
+			wantTier: "apps",
+			wantPath: "apps/sealed-secrets",
+		},
+		{
+			name: "platform true infers infrastructure",
+			addon: butlerv1alpha1.AddonDefinition{
+				Spec: butlerv1alpha1.AddonDefinitionSpec{
+					Platform: true,
+				},
+			},
+			wantTier: "infrastructure",
+			wantPath: "infrastructure/sealed-secrets",
+		},
+		{
+			name: "non-platform defaults to apps",
+			addon: butlerv1alpha1.AddonDefinition{
+				Spec: butlerv1alpha1.AddonDefinitionSpec{},
+			},
+			wantTier: "apps",
+			wantPath: "apps/sealed-secrets",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tier := tt.addon.GetEffectiveTier()
+			if tier != tt.wantTier {
+				t.Errorf("GetEffectiveTier() = %q, want %q", tier, tt.wantTier)
+			}
+
+			path := layout.GetReleasePath(tier, "sealed-secrets")
+			if path != tt.wantPath {
+				t.Errorf("GetReleasePath() = %q, want %q", path, tt.wantPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Replaces `categoryFromPlatform()` with `GetEffectiveTier()` from butler-api v0.14.0. Export handlers now read the `Tier` field first, falling back to the `Platform` boolean when `Tier` is unset.

This lets non-platform addons like prometheus-operator and sealed-secrets land in `infrastructure/` without changing their lifecycle semantics.

### Changes

- `DiscoverHelmReleases` (discovery.go): `categoryFromPlatform(addonDef.Spec.Platform)` → `addonDef.GetEffectiveTier()`
- `ExportAddon` handler (gitops.go): Platform if/else → single `GetEffectiveTier()` call
- `ExportManagementCatalogAddon` handler (gitops.go): same pattern
- Removed `categoryFromPlatform()` (dead code after migration)
- Bumped butler-api dependency to v0.14.0
- Added `TestAddonTierToReleasePath` covering all 5 resolution paths

### ADR-015 PR chain

1. ~~butler-api#35 (schema)~~ — merged
2. **butler-server (this PR)** — discovery + export logic
3. butler-charts (next) — set `tier: infrastructure` on 4 addon definitions

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/gitops/` — 22 tests pass (5 new tier tests + 17 existing)
- [ ] Manual: export a non-platform addon with `tier: infrastructure` and verify it lands in `infrastructure/`