### PR TITLE
ADR-014 PR 3: Wire platform role into auth paths and middleware

### DIFF
--- a/docs/architecture/ADR-014-group-platform-role.md
+++ b/docs/architecture/ADR-014-group-platform-role.md
@@ -429,6 +429,7 @@ The `/api/auth/refresh-permissions` endpoint already re-queries the User CRD. Ex
 - The two auth paths (butler-server and kubectl-direct) remain separate.
 - Session helper changes touch ~12 methods, increasing the risk surface of this change. Thorough unit tests are required.
 - `isPlatformAdmin` deprecation creates a transitional period where both fields coexist.
+- CLI device flow refresh cannot re-evaluate IdP group membership. The refresh path exchanges a stored refresh token for a new SA token and kubeconfig, but has no OIDC token to extract groups from. Users who hold platform admin solely through IdP group membership (no `platformRole` set on their User CRD) will lose admin status on first CLI refresh. Their `ClusterRoleBinding` is removed accordingly and CLI operations requiring platform admin will fail. This is consistent with the "next login" revocation model: the refresh is a re-evaluation point that can only use CRD-level sources. Operators relying on CLI access for platform admins should set `platformRole: admin` on the User CRD as a manual override rather than depending solely on group membership for CLI use cases.
 
 ## Related ADRs
 

--- a/internal/api/handlers/auth_device.go
+++ b/internal/api/handlers/auth_device.go
@@ -225,14 +225,14 @@ func (h *DeviceFlowHandler) DeviceApprove(w http.ResponseWriter, r *http.Request
 	}
 
 	session := &auth.UserSession{
-		Subject:         user.Subject,
-		Email:           user.Email,
-		Name:            user.Name,
-		Picture:         user.Picture,
-		Provider:        user.Provider,
-		Groups:          user.Groups,
-		Teams:           teams,
-		IsPlatformAdmin: user.IsPlatformAdmin,
+		Subject:      user.Subject,
+		Email:        user.Email,
+		Name:         user.Name,
+		Picture:      user.Picture,
+		Provider:     user.Provider,
+		Groups:       user.Groups,
+		Teams:        teams,
+		PlatformRole: user.PlatformRole,
 	}
 
 	h.deviceStore.Approve(req.DeviceCode, session)
@@ -288,10 +288,10 @@ func (h *DeviceFlowHandler) DeviceRefresh(w http.ResponseWriter, r *http.Request
 	}
 
 	session := &auth.UserSession{
-		Email:           email,
-		Name:            userCRD.DisplayName,
-		Teams:           teams,
-		IsPlatformAdmin: userCRD.IsPlatformAdmin,
+		Email:        email,
+		Name:         userCRD.DisplayName,
+		Teams:        teams,
+		PlatformRole: auth.EffectivePlatformRole(userCRD.PlatformRole, userCRD.IsPlatformAdmin, ""),
 	}
 
 	result, err := h.provisionCLIAccess(r, session)
@@ -319,6 +319,7 @@ type cliUserResponse struct {
 	Name            string                `json:"name"`
 	Teams           []auth.TeamMembership `json:"teams"`
 	IsPlatformAdmin bool                  `json:"isPlatformAdmin,omitempty"`
+	PlatformRole    string                `json:"platformRole,omitempty"`
 }
 
 // provisionCLIAccess creates (or updates) the SA, RoleBindings, token, and
@@ -333,7 +334,7 @@ func (h *DeviceFlowHandler) provisionCLIAccess(r *http.Request, session *auth.Us
 	}
 
 	// Ensure RoleBindings
-	if err := h.saManager.EnsureRoleBindings(ctx, sa.Name, session.Email, session.Teams, session.IsPlatformAdmin); err != nil {
+	if err := h.saManager.EnsureRoleBindings(ctx, sa.Name, session.Email, session.Teams, session.PlatformRole == auth.RoleAdmin); err != nil {
 		return nil, fmt.Errorf("ensure role bindings: %w", err)
 	}
 
@@ -363,7 +364,8 @@ func (h *DeviceFlowHandler) provisionCLIAccess(r *http.Request, session *auth.Us
 			Email:           session.Email,
 			Name:            session.Name,
 			Teams:           session.Teams,
-			IsPlatformAdmin: session.IsPlatformAdmin,
+			IsPlatformAdmin: session.PlatformRole == auth.RoleAdmin,
+			PlatformRole:    session.PlatformRole,
 		},
 		Kubeconfig:       base64.StdEncoding.EncodeToString(kubeconfigBytes),
 		ExpiresAt:        expiresAt.Format(time.RFC3339),

--- a/internal/api/handlers/auth_oidc.go
+++ b/internal/api/handlers/auth_oidc.go
@@ -73,6 +73,7 @@ type UserResponse struct {
 	Picture         string                `json:"picture,omitempty"`
 	Teams           []auth.TeamMembership `json:"teams"`
 	IsPlatformAdmin bool                  `json:"isPlatformAdmin,omitempty"`
+	PlatformRole    string                `json:"platformRole,omitempty"`
 }
 
 // Login initiates the OIDC login flow.
@@ -151,7 +152,8 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	// IMPORTANT: Ensure User CRD exists for this SSO user
 	// This is called on EVERY SSO login to create/update the user record
-	var isPlatformAdmin bool
+	var crdPlatformRole string
+	var crdIsPlatformAdmin bool
 	user, err := h.userService.EnsureSSOUser(r.Context(), auth.EnsureSSOUserRequest{
 		Email:       claims.Email,
 		DisplayName: claims.Name,
@@ -177,9 +179,14 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Check if user has platform admin privileges from User CRD
-		isPlatformAdmin = user.IsPlatformAdmin
+		crdPlatformRole = user.PlatformRole
+		crdIsPlatformAdmin = user.IsPlatformAdmin
 	}
+
+	// Compute effective platform role: max of CRD role, deprecated
+	// isPlatformAdmin bool, and IdP group-derived role.
+	groupRole := auth.ResolvePlatformRole(claims.Groups, h.oidcProvider.GetPlatformRoleGroups())
+	effectivePlatformRole := auth.EffectivePlatformRole(crdPlatformRole, crdIsPlatformAdmin, groupRole)
 
 	// Resolve team memberships
 	teams, err := h.teamResolver.ResolveTeams(r.Context(), claims.Email, claims.Groups)
@@ -190,14 +197,14 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	// Create user session
 	session := &auth.UserSession{
-		Subject:         claims.Subject,
-		Email:           claims.Email,
-		Name:            claims.Name,
-		Picture:         claims.Picture,
-		Provider:        h.oidcProvider.GetDisplayName(),
-		Groups:          claims.Groups,
-		Teams:           teams,
-		IsPlatformAdmin: isPlatformAdmin,
+		Subject:      claims.Subject,
+		Email:        claims.Email,
+		Name:         claims.Name,
+		Picture:      claims.Picture,
+		Provider:     h.oidcProvider.GetDisplayName(),
+		Groups:       claims.Groups,
+		Teams:        teams,
+		PlatformRole: effectivePlatformRole,
 	}
 
 	// Generate session token
@@ -226,7 +233,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	h.logger.Info("User logged in via SSO",
 		"email", claims.Email,
 		"teams", len(teams),
-		"isPlatformAdmin", isPlatformAdmin,
+		"platformRole", effectivePlatformRole,
 	)
 	audit.RecordLogin(h.auditEmitter, claims.Email, "sso", r.RemoteAddr)
 
@@ -305,15 +312,19 @@ func (h *AuthHandler) InternalUserLogin(w http.ResponseWriter, r *http.Request) 
 		teams = []auth.TeamMembership{}
 	}
 
+	// Compute effective platform role from CRD fields. Internal users
+	// have no IdP groups, so only CRD-driven sources apply.
+	platformRole := auth.EffectivePlatformRole(user.PlatformRole, user.IsPlatformAdmin, "")
+
 	// Create session
 	session := &auth.UserSession{
-		Subject:         "internal:" + user.Name,
-		Email:           user.Email,
-		Name:            user.DisplayName,
-		Picture:         user.Avatar,
-		Provider:        "internal",
-		Teams:           teams,
-		IsPlatformAdmin: user.IsPlatformAdmin, // Propagate from User CRD
+		Subject:      "internal:" + user.Name,
+		Email:        user.Email,
+		Name:         user.DisplayName,
+		Picture:      user.Avatar,
+		Provider:     "internal",
+		Teams:        teams,
+		PlatformRole: platformRole,
 	}
 
 	if session.Name == "" {
@@ -340,7 +351,7 @@ func (h *AuthHandler) InternalUserLogin(w http.ResponseWriter, r *http.Request) 
 	h.logger.Info("User logged in via password",
 		"email", user.Email,
 		"teams", len(teams),
-		"isPlatformAdmin", user.IsPlatformAdmin,
+		"platformRole", platformRole,
 	)
 	audit.RecordLogin(h.auditEmitter, user.Email, "internal", r.RemoteAddr)
 
@@ -350,7 +361,8 @@ func (h *AuthHandler) InternalUserLogin(w http.ResponseWriter, r *http.Request) 
 			Name:            session.Name,
 			Picture:         user.Avatar,
 			Teams:           teams,
-			IsPlatformAdmin: user.IsPlatformAdmin,
+			IsPlatformAdmin: platformRole == auth.RoleAdmin,
+			PlatformRole:    platformRole,
 		},
 	})
 }
@@ -468,8 +480,10 @@ func (h *AuthHandler) RefreshPermissions(w http.ResponseWriter, r *http.Request)
 			writeError(w, http.StatusForbidden, "Account is disabled")
 			return
 		}
-		// Update platform admin status from User CRD
-		user.IsPlatformAdmin = userCRD.IsPlatformAdmin
+		// Re-evaluate platform role from current CRD state and session groups.
+		// The session carries the user's IdP groups from their last login.
+		groupRole := auth.ResolvePlatformRole(user.Groups, h.oidcProvider.GetPlatformRoleGroups())
+		user.PlatformRole = auth.EffectivePlatformRole(userCRD.PlatformRole, userCRD.IsPlatformAdmin, groupRole)
 	}
 
 	// Update user's team memberships
@@ -497,7 +511,7 @@ func (h *AuthHandler) RefreshPermissions(w http.ResponseWriter, r *http.Request)
 	h.logger.Info("Permissions refreshed",
 		"email", user.Email,
 		"teams", len(teams),
-		"isPlatformAdmin", user.IsPlatformAdmin,
+		"platformRole", user.PlatformRole,
 	)
 
 	// Return updated user info (same format as /api/auth/me)
@@ -506,7 +520,8 @@ func (h *AuthHandler) RefreshPermissions(w http.ResponseWriter, r *http.Request)
 		Name:            user.Name,
 		Picture:         user.Picture,
 		Teams:           teams,
-		IsPlatformAdmin: user.IsPlatformAdmin,
+		IsPlatformAdmin: user.PlatformRole == auth.RoleAdmin,
+		PlatformRole:    user.PlatformRole,
 	})
 }
 
@@ -525,6 +540,7 @@ func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 		Picture:         user.Picture,
 		Teams:           user.Teams,
 		IsPlatformAdmin: user.IsPlatformAdmin,
+		PlatformRole:    user.PlatformRole,
 	})
 }
 
@@ -540,6 +556,7 @@ func (h *AuthHandler) Teams(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"teams":           user.Teams,
 		"isPlatformAdmin": user.IsPlatformAdmin,
+		"platformRole":    user.PlatformRole,
 	})
 }
 
@@ -575,15 +592,15 @@ func (h *AuthHandler) GetProviders(w http.ResponseWriter, r *http.Request) {
 // createLegacyAdminSession creates a session for the legacy admin user (bootstrap/dev mode).
 // The legacy admin is a PLATFORM ADMIN with full access to everything.
 func (h *AuthHandler) createLegacyAdminSession(w http.ResponseWriter, r *http.Request) {
-	// Create session for the admin user with PLATFORM ADMIN privileges
-	// Platform admins bypass team checks entirely
+	// Create session for the admin user with PLATFORM ADMIN privileges.
+	// Platform admins bypass team checks entirely.
 	session := &auth.UserSession{
-		Subject:         "legacy:admin",
-		Email:           "admin@butler.local",
-		Name:            "Platform Administrator",
-		Provider:        "legacy",
-		IsPlatformAdmin: true,                    // THIS IS THE KEY FIX
-		Teams:           []auth.TeamMembership{}, // No teams needed for platform admin
+		Subject:      "legacy:admin",
+		Email:        "admin@butler.local",
+		Name:         "Platform Administrator",
+		Provider:     "legacy",
+		PlatformRole: auth.RoleAdmin,
+		Teams:        []auth.TeamMembership{},
 	}
 
 	token, err := h.sessionService.CreateSession(session)
@@ -611,6 +628,7 @@ func (h *AuthHandler) createLegacyAdminSession(w http.ResponseWriter, r *http.Re
 			Name:            session.Name,
 			Teams:           session.Teams,
 			IsPlatformAdmin: true,
+			PlatformRole:    auth.RoleAdmin,
 		},
 	})
 }

--- a/internal/api/handlers/users.go
+++ b/internal/api/handlers/users.go
@@ -89,6 +89,7 @@ type UserListResponse struct {
 	SSOProvider     string   `json:"ssoProvider,omitempty"`
 	Teams           []string `json:"teams,omitempty"`
 	IsPlatformAdmin bool     `json:"isPlatformAdmin,omitempty"`
+	PlatformRole    string   `json:"platformRole,omitempty"`
 }
 
 // CreateUserResponseBody is the response for user creation.
@@ -140,6 +141,7 @@ func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 			AuthType:        u.AuthType,
 			SSOProvider:     u.SSOProvider,
 			IsPlatformAdmin: u.IsPlatformAdmin,
+			PlatformRole:    u.PlatformRole,
 		}
 
 		// Add team membership info
@@ -202,6 +204,7 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Disabled:        result.User.Disabled,
 			AuthType:        result.User.AuthType,
 			IsPlatformAdmin: result.User.IsPlatformAdmin,
+			PlatformRole:    result.User.PlatformRole,
 		},
 		InviteURL: result.InviteURL,
 	})
@@ -242,6 +245,7 @@ func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request) {
 		SSOProvider:     user.SSOProvider,
 		Teams:           teams,
 		IsPlatformAdmin: user.IsPlatformAdmin,
+		PlatformRole:    user.PlatformRole,
 	})
 }
 
@@ -403,14 +407,16 @@ func (h *UserHandler) SetPassword(w http.ResponseWriter, r *http.Request) {
 		teams = []auth.TeamMembership{}
 	}
 
+	platformRole := auth.EffectivePlatformRole(user.PlatformRole, user.IsPlatformAdmin, "")
+
 	session := &auth.UserSession{
-		Subject:         "internal:" + user.Name,
-		Email:           user.Email,
-		Name:            user.DisplayName,
-		Picture:         user.Avatar,
-		Provider:        "internal",
-		Teams:           teams,
-		IsPlatformAdmin: user.IsPlatformAdmin,
+		Subject:      "internal:" + user.Name,
+		Email:        user.Email,
+		Name:         user.DisplayName,
+		Picture:      user.Avatar,
+		Provider:     "internal",
+		Teams:        teams,
+		PlatformRole: platformRole,
 	}
 
 	if session.Name == "" {
@@ -448,6 +454,7 @@ func (h *UserHandler) SetPassword(w http.ResponseWriter, r *http.Request) {
 			Phase:           user.Phase,
 			AuthType:        user.AuthType,
 			IsPlatformAdmin: user.IsPlatformAdmin,
+			PlatformRole:    user.PlatformRole,
 		},
 	})
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -79,16 +79,26 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 	var oidcProvider *auth.OIDCProvider
 	if cfg.Config.IsOIDCConfigured() {
 		var err error
+		// Load platformRoleGroups from IdentityProvider CRDs. These map IdP
+		// groups to platform-wide roles (admin, viewer) at session creation.
+		platformRoleGroups := auth.LoadAllPlatformRoleGroups(context.Background(), cfg.K8sClient.Dynamic())
+		if len(platformRoleGroups) > 0 {
+			cfg.Logger.Info("Loaded platform role groups from IdentityProvider CRDs",
+				"count", len(platformRoleGroups),
+			)
+		}
+
 		oidcProvider, err = auth.NewOIDCProvider(context.Background(), &auth.OIDCConfig{
-			IssuerURL:       cfg.Config.OIDC.IssuerURL,
-			ClientID:        cfg.Config.OIDC.ClientID,
-			ClientSecret:    cfg.Config.OIDC.ClientSecret,
-			RedirectURL:     cfg.Config.OIDC.RedirectURL,
-			Scopes:          cfg.Config.OIDC.Scopes,
-			HostedDomain:    cfg.Config.OIDC.HostedDomain,
-			GroupsClaim:     cfg.Config.OIDC.GroupsClaim,
-			EmailClaim:      cfg.Config.OIDC.EmailClaim,
-			GoogleWorkspace: loadGoogleWorkspaceConfig(&cfg.Config.OIDC),
+			IssuerURL:          cfg.Config.OIDC.IssuerURL,
+			ClientID:           cfg.Config.OIDC.ClientID,
+			ClientSecret:       cfg.Config.OIDC.ClientSecret,
+			RedirectURL:        cfg.Config.OIDC.RedirectURL,
+			Scopes:             cfg.Config.OIDC.Scopes,
+			HostedDomain:       cfg.Config.OIDC.HostedDomain,
+			GroupsClaim:        cfg.Config.OIDC.GroupsClaim,
+			EmailClaim:         cfg.Config.OIDC.EmailClaim,
+			GoogleWorkspace:    loadGoogleWorkspaceConfig(&cfg.Config.OIDC),
+			PlatformRoleGroups: platformRoleGroups,
 		}, cfg.Logger)
 		if err != nil {
 			cfg.Logger.Error("Failed to initialize OIDC provider", "error", err)
@@ -152,6 +162,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 		info := &websocket.SessionInfo{
 			Email:           session.Email,
 			IsPlatformAdmin: session.IsPlatformAdmin,
+			PlatformRole:    session.PlatformRole,
 		}
 		for _, tm := range session.Teams {
 			info.Teams = append(info.Teams, websocket.TeamInfo{Name: tm.Name})

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -183,10 +183,10 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 			}
 
 			// Check if user has any team membership (required for access).
-			// Platform admins bypass above. Platform viewers have synthetic
-			// membership in all teams, so they pass here on team count alone
-			// (re-resolution above populates their teams list). Regular users
-			// with no teams are rejected.
+			// Platform admins bypass above. Platform viewers may have zero
+			// explicit team memberships but still need access (session helpers
+			// provide synthetic membership at the application level). Regular
+			// users with no teams are rejected.
 			if len(user.Teams) == 0 && user.PlatformRole != RoleViewer {
 				http.Error(w, `{"error":"no team access - contact your administrator"}`, http.StatusForbidden)
 				return

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -83,8 +83,10 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 			// the header is absent, which falls back to team-level scoping.
 			selectedEnv := r.Header.Get("X-Butler-Environment")
 
-			// Platform admins path
-			if user.IsPlatformAdmin {
+			// Platform admins path: only full admins get the fast path
+			// with impersonation and team-scoping. Platform viewers go
+			// through the normal team re-resolution path below.
+			if user.PlatformRole == RoleAdmin {
 				// When requests come through the Backstage portal proxy, all
 				// requests authenticate as the admin service account. The proxy
 				// forwards the real user's email via X-Butler-User-Email so the
@@ -180,9 +182,12 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 				user.Teams = freshTeams
 			}
 
-			// Check if user has any team membership (required for access)
-			// Platform admins already bypassed above, so this only affects regular users
-			if len(user.Teams) == 0 {
+			// Check if user has any team membership (required for access).
+			// Platform admins bypass above. Platform viewers have synthetic
+			// membership in all teams, so they pass here on team count alone
+			// (re-resolution above populates their teams list). Regular users
+			// with no teams are rejected.
+			if len(user.Teams) == 0 && user.PlatformRole != RoleViewer {
 				http.Error(w, `{"error":"no team access - contact your administrator"}`, http.StatusForbidden)
 				return
 			}
@@ -246,8 +251,8 @@ func RequireTeam(teamName string) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Platform admins have access to all teams
-			if user.IsPlatformAdmin {
+			// Platform admins and viewers have access to all teams
+			if user.PlatformRole == RoleAdmin || user.PlatformRole == RoleViewer {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -293,7 +298,7 @@ func RequireAdmin() func(http.Handler) http.Handler {
 
 // RequirePlatformAdmin creates middleware that requires platform admin privileges.
 // Use this for operations that should only be available to platform-level admins,
-// not team-level admins.
+// not team-level admins. Platform viewers do NOT pass this check.
 func RequirePlatformAdmin() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -303,8 +308,31 @@ func RequirePlatformAdmin() func(http.Handler) http.Handler {
 				return
 			}
 
-			if !user.IsPlatformAdmin {
+			if user.PlatformRole != RoleAdmin {
 				http.Error(w, `{"error":"forbidden: platform admin required"}`, http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequirePlatformViewer creates middleware that requires platform viewer or
+// higher privileges. Both platform admin and platform viewer pass this check.
+// Use this for read-only platform-wide endpoints (list all clusters, view
+// audit logs, etc.).
+func RequirePlatformViewer() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user := UserFromContext(r.Context())
+			if user == nil {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+
+			if !user.IsPlatformViewerOrAbove() {
+				http.Error(w, `{"error":"forbidden: platform viewer or admin required"}`, http.StatusForbidden)
 				return
 			}
 
@@ -340,8 +368,8 @@ func (c *ClusterTeamAuthz) RequireAccess() func(http.Handler) http.Handler {
 				return
 			}
 
-			// Platform admins have access to all clusters
-			if user.IsPlatformAdmin {
+			// Platform admins and viewers have access to all clusters
+			if user.PlatformRole == RoleAdmin || user.PlatformRole == RoleViewer {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// withUser injects a UserSession into the request context for middleware tests.
+func withUser(r *http.Request, user *UserSession) *http.Request {
+	ctx := context.WithValue(r.Context(), userContextKey, user)
+	return r.WithContext(ctx)
+}
+
+// dummyHandler is a pass-through handler used to confirm middleware did not block.
+var dummyHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+func TestRequirePlatformAdmin_NoUser_401(t *testing.T) {
+	mw := RequirePlatformAdmin()(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/settings", nil)
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("got %d, want 401", rec.Code)
+	}
+}
+
+func TestRequirePlatformAdmin_ViewerBlocked_403(t *testing.T) {
+	mw := RequirePlatformAdmin()(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/settings", nil)
+	req = withUser(req, &UserSession{Email: "viewer@example.com", PlatformRole: RoleViewer})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("got %d, want 403", rec.Code)
+	}
+}
+
+func TestRequirePlatformAdmin_RegularUserBlocked_403(t *testing.T) {
+	mw := RequirePlatformAdmin()(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/settings", nil)
+	req = withUser(req, &UserSession{Email: "user@example.com", PlatformRole: ""})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("got %d, want 403", rec.Code)
+	}
+}
+
+func TestRequirePlatformAdmin_AdminPasses(t *testing.T) {
+	mw := RequirePlatformAdmin()(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/settings", nil)
+	req = withUser(req, &UserSession{Email: "admin@example.com", PlatformRole: RoleAdmin})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+}
+
+func TestRequirePlatformViewer_NoUser_401(t *testing.T) {
+	mw := RequirePlatformViewer()(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("got %d, want 401", rec.Code)
+	}
+}
+
+func TestRequirePlatformViewer_RegularUserBlocked_403(t *testing.T) {
+	mw := RequirePlatformViewer()(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req = withUser(req, &UserSession{Email: "user@example.com", PlatformRole: ""})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("got %d, want 403", rec.Code)
+	}
+}
+
+func TestRequirePlatformViewer_ViewerPasses(t *testing.T) {
+	mw := RequirePlatformViewer()(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req = withUser(req, &UserSession{Email: "viewer@example.com", PlatformRole: RoleViewer})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+}
+
+func TestRequirePlatformViewer_AdminPasses(t *testing.T) {
+	mw := RequirePlatformViewer()(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req = withUser(req, &UserSession{Email: "admin@example.com", PlatformRole: RoleAdmin})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+}
+
+// RequireTeam middleware tests with platform roles.
+
+func TestRequireTeam_ViewerBypasses(t *testing.T) {
+	mw := RequireTeam("acme")(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/teams/acme/clusters", nil)
+	req = withUser(req, &UserSession{Email: "viewer@example.com", PlatformRole: RoleViewer})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("got %d, want 200 (platform viewer should bypass team gate)", rec.Code)
+	}
+}
+
+func TestRequireTeam_AdminBypasses(t *testing.T) {
+	mw := RequireTeam("acme")(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/teams/acme/clusters", nil)
+	req = withUser(req, &UserSession{Email: "admin@example.com", PlatformRole: RoleAdmin})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("got %d, want 200 (platform admin should bypass team gate)", rec.Code)
+	}
+}
+
+func TestRequireTeam_NonMemberBlocked(t *testing.T) {
+	mw := RequireTeam("acme")(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/teams/acme/clusters", nil)
+	req = withUser(req, &UserSession{
+		Email: "user@example.com",
+		Teams: []TeamMembership{{Name: "other", Role: RoleViewer}},
+	})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("got %d, want 403", rec.Code)
+	}
+}
+
+func TestRequireTeam_MemberPasses(t *testing.T) {
+	mw := RequireTeam("acme")(dummyHandler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/teams/acme/clusters", nil)
+	req = withUser(req, &UserSession{
+		Email: "user@example.com",
+		Teams: []TeamMembership{{Name: "acme", Role: RoleViewer}},
+	})
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+}

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -69,6 +69,10 @@ type OIDCConfig struct {
 	// GoogleWorkspace holds optional Google Admin SDK config for fetching groups.
 	// Required for Google Workspace because OIDC tokens don't include groups.
 	GoogleWorkspace *GoogleGroupsConfig
+
+	// PlatformRoleGroups maps IdP groups to platform-wide roles. Loaded
+	// from the IdentityProvider CRD's spec.platformRoleGroups field.
+	PlatformRoleGroups []PlatformRoleGroupEntry
 }
 
 // OIDCProvider handles OIDC authentication flows.
@@ -292,6 +296,12 @@ func (p *OIDCProvider) GetDisplayName() string {
 	default:
 		return "SSO"
 	}
+}
+
+// GetPlatformRoleGroups returns the platform role group entries configured
+// on this provider's IdentityProvider CRD.
+func (p *OIDCProvider) GetPlatformRoleGroups() []PlatformRoleGroupEntry {
+	return p.config.PlatformRoleGroups
 }
 
 // HasGroupSync returns true if Google Workspace group sync is configured.

--- a/internal/auth/platform_role.go
+++ b/internal/auth/platform_role.go
@@ -16,7 +16,75 @@ limitations under the License.
 
 package auth
 
-import "strings"
+import (
+	"context"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// LoadPlatformRoleGroups reads the IdentityProvider CRD and returns its
+// spec.platformRoleGroups entries. Returns nil (not an error) if the CRD
+// has no platformRoleGroups configured or if the CRD is not found.
+func LoadPlatformRoleGroups(ctx context.Context, client dynamic.Interface, idpName string) []PlatformRoleGroupEntry {
+	if client == nil || idpName == "" {
+		return nil
+	}
+
+	idp, err := client.Resource(IdentityProviderGVR).Get(ctx, idpName, metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+
+	return parsePlatformRoleGroups(idp)
+}
+
+// LoadAllPlatformRoleGroups reads all IdentityProvider CRDs and returns
+// the platformRoleGroups from whichever one is configured. For single-IdP
+// deployments this returns the one IdP's groups. For multi-IdP setups,
+// callers should use LoadPlatformRoleGroups with a specific name.
+func LoadAllPlatformRoleGroups(ctx context.Context, client dynamic.Interface) []PlatformRoleGroupEntry {
+	if client == nil {
+		return nil
+	}
+
+	list, err := client.Resource(IdentityProviderGVR).List(ctx, metav1.ListOptions{})
+	if err != nil || len(list.Items) == 0 {
+		return nil
+	}
+
+	// Merge from all IdPs; in practice most deployments have one.
+	var all []PlatformRoleGroupEntry
+	for i := range list.Items {
+		all = append(all, parsePlatformRoleGroups(&list.Items[i])...)
+	}
+	return all
+}
+
+// parsePlatformRoleGroups extracts platformRoleGroups from an unstructured
+// IdentityProvider object.
+func parsePlatformRoleGroups(idp *unstructured.Unstructured) []PlatformRoleGroupEntry {
+	groups, found, err := unstructured.NestedSlice(idp.Object, "spec", "platformRoleGroups")
+	if err != nil || !found || len(groups) == 0 {
+		return nil
+	}
+
+	var entries []PlatformRoleGroupEntry
+	for _, g := range groups {
+		entry, ok := g.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := entry["name"].(string)
+		role, _ := entry["role"].(string)
+		if name != "" && role != "" {
+			entries = append(entries, PlatformRoleGroupEntry{Name: name, Role: role})
+		}
+	}
+	return entries
+}
 
 // PlatformRoleGroupEntry maps an IdP group to a platform-wide role.
 // This mirrors the butler-api type for use in session-level resolution

--- a/internal/auth/platform_role.go
+++ b/internal/auth/platform_role.go
@@ -45,6 +45,10 @@ func LoadPlatformRoleGroups(ctx context.Context, client dynamic.Interface, idpNa
 // the platformRoleGroups from whichever one is configured. For single-IdP
 // deployments this returns the one IdP's groups. For multi-IdP setups,
 // callers should use LoadPlatformRoleGroups with a specific name.
+//
+// Today butler-server supports a single OIDC provider, so merging across
+// all CRDs is safe. If multi-IdP support is added, this function should
+// be replaced with per-provider loading to preserve IdP isolation.
 func LoadAllPlatformRoleGroups(ctx context.Context, client dynamic.Interface) []PlatformRoleGroupEntry {
 	if client == nil {
 		return nil

--- a/internal/auth/platform_role_test.go
+++ b/internal/auth/platform_role_test.go
@@ -282,11 +282,13 @@ func TestEffectivePlatformRole_LoginScenarios(t *testing.T) {
 	}
 }
 
-// TestMultiIdP_Isolation verifies that groups from one IdP are not matched
-// against another IdP's platformRoleGroups configuration. Each IdP has its
-// own list, and ResolvePlatformRole is called per-IdP. A user in the Entra
-// "butler-platform-admin" group should not get admin from the Google config.
-func TestMultiIdP_Isolation(t *testing.T) {
+// TestResolvePlatformRole_PerIdPSeparation verifies that ResolvePlatformRole
+// produces correct results when called with separate per-IdP group lists.
+// Each IdP has its own platformRoleGroups config; a user in Entra's
+// "butler-platform-admin" group does not match Google's config and vice versa.
+// Note: this tests function-level behavior. System-level multi-IdP isolation
+// requires per-provider loading when butler-server gains multi-IdP support.
+func TestResolvePlatformRole_PerIdPSeparation(t *testing.T) {
 	entraGroups := []PlatformRoleGroupEntry{
 		{Name: "butler-platform-admin", Role: RoleAdmin},
 	}

--- a/internal/auth/platform_role_test.go
+++ b/internal/auth/platform_role_test.go
@@ -201,6 +201,200 @@ func TestEffectivePlatformRole(t *testing.T) {
 	}
 }
 
+// TestEffectivePlatformRole_LoginScenarios tests the full effective role
+// computation that happens at session creation in the OIDC callback.
+// Each case mirrors a real login scenario described in ADR-014.
+func TestEffectivePlatformRole_LoginScenarios(t *testing.T) {
+	entraAdminGroup := []PlatformRoleGroupEntry{
+		{Name: "butler-platform-admin", Role: RoleAdmin},
+		{Name: "butler-platform-viewers", Role: RoleViewer},
+	}
+
+	tests := []struct {
+		name               string
+		userGroups         []string
+		platformRoleGroups []PlatformRoleGroupEntry
+		crdPlatformRole    string
+		crdIsPlatformAdmin bool
+		want               string
+	}{
+		{
+			name:               "admin group yields admin session",
+			userGroups:         []string{"butler-platform-admin"},
+			platformRoleGroups: entraAdminGroup,
+			want:               RoleAdmin,
+		},
+		{
+			name:               "viewer group yields viewer session",
+			userGroups:         []string{"butler-platform-viewers"},
+			platformRoleGroups: entraAdminGroup,
+			want:               RoleViewer,
+		},
+		{
+			name:               "both groups - admin wins (highest role)",
+			userGroups:         []string{"butler-platform-admin", "butler-platform-viewers"},
+			platformRoleGroups: entraAdminGroup,
+			want:               RoleAdmin,
+		},
+		{
+			name:               "no platform group + isPlatformAdmin on CRD - admin (backwards compat)",
+			userGroups:         []string{"unrelated-team-group"},
+			platformRoleGroups: entraAdminGroup,
+			crdIsPlatformAdmin: true,
+			want:               RoleAdmin,
+		},
+		{
+			name:               "no platform group + platformRole viewer on CRD - viewer",
+			userGroups:         []string{"unrelated-team-group"},
+			platformRoleGroups: entraAdminGroup,
+			crdPlatformRole:    RoleViewer,
+			want:               RoleViewer,
+		},
+		{
+			name:               "no group match, no CRD role - empty",
+			userGroups:         []string{"unrelated-team-group"},
+			platformRoleGroups: entraAdminGroup,
+			want:               "",
+		},
+		{
+			name:               "CRD viewer + group admin - admin wins",
+			userGroups:         []string{"butler-platform-admin"},
+			platformRoleGroups: entraAdminGroup,
+			crdPlatformRole:    RoleViewer,
+			want:               RoleAdmin,
+		},
+		{
+			name:               "CRD admin + group viewer - admin wins",
+			userGroups:         []string{"butler-platform-viewers"},
+			platformRoleGroups: entraAdminGroup,
+			crdPlatformRole:    RoleAdmin,
+			want:               RoleAdmin,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groupRole := ResolvePlatformRole(tt.userGroups, tt.platformRoleGroups)
+			got := EffectivePlatformRole(tt.crdPlatformRole, tt.crdIsPlatformAdmin, groupRole)
+			if got != tt.want {
+				t.Errorf("effective role = %q, want %q (groupRole=%q)", got, tt.want, groupRole)
+			}
+		})
+	}
+}
+
+// TestMultiIdP_Isolation verifies that groups from one IdP are not matched
+// against another IdP's platformRoleGroups configuration. Each IdP has its
+// own list, and ResolvePlatformRole is called per-IdP. A user in the Entra
+// "butler-platform-admin" group should not get admin from the Google config.
+func TestMultiIdP_Isolation(t *testing.T) {
+	entraGroups := []PlatformRoleGroupEntry{
+		{Name: "butler-platform-admin", Role: RoleAdmin},
+	}
+	googleGroups := []PlatformRoleGroupEntry{
+		{Name: "butler-admins@example.com", Role: RoleAdmin},
+	}
+
+	// User is in the Entra admin group
+	userGroups := []string{"butler-platform-admin"}
+
+	// Resolving against Entra config should match
+	entraRole := ResolvePlatformRole(userGroups, entraGroups)
+	if entraRole != RoleAdmin {
+		t.Errorf("Entra resolution = %q, want admin", entraRole)
+	}
+
+	// Resolving against Google config should NOT match
+	googleRole := ResolvePlatformRole(userGroups, googleGroups)
+	if googleRole != "" {
+		t.Errorf("Google resolution = %q, want empty (isolation violated)", googleRole)
+	}
+
+	// Reverse: user in Google admin group should not match Entra config
+	googleUser := []string{"butler-admins@example.com"}
+	entraRoleForGoogleUser := ResolvePlatformRole(googleUser, entraGroups)
+	if entraRoleForGoogleUser != "" {
+		t.Errorf("Entra resolution for Google user = %q, want empty", entraRoleForGoogleUser)
+	}
+	googleRoleForGoogleUser := ResolvePlatformRole(googleUser, googleGroups)
+	if googleRoleForGoogleUser != RoleAdmin {
+		t.Errorf("Google resolution for Google user = %q, want admin", googleRoleForGoogleUser)
+	}
+}
+
+// TestRefreshPermissions_RoleChange tests the pattern used in RefreshPermissions:
+// re-evaluating group membership yields an updated role when group membership
+// changes between login and refresh.
+func TestRefreshPermissions_RoleChange(t *testing.T) {
+	platformRoleGroups := []PlatformRoleGroupEntry{
+		{Name: "butler-platform-admin", Role: RoleAdmin},
+		{Name: "butler-platform-viewers", Role: RoleViewer},
+	}
+
+	tests := []struct {
+		name            string
+		groupsAtLogin   []string
+		groupsAtRefresh []string
+		crdPlatformRole string
+		crdIsPlatformAdmin bool
+		wantAtLogin     string
+		wantAtRefresh   string
+	}{
+		{
+			name:            "user removed from admin group - role downgraded",
+			groupsAtLogin:   []string{"butler-platform-admin"},
+			groupsAtRefresh: []string{"unrelated-group"},
+			wantAtLogin:     RoleAdmin,
+			wantAtRefresh:   "",
+		},
+		{
+			name:            "user added to viewer group - role upgraded",
+			groupsAtLogin:   []string{"unrelated-group"},
+			groupsAtRefresh: []string{"butler-platform-viewers"},
+			wantAtLogin:     "",
+			wantAtRefresh:   RoleViewer,
+		},
+		{
+			name:            "user upgraded from viewer to admin group",
+			groupsAtLogin:   []string{"butler-platform-viewers"},
+			groupsAtRefresh: []string{"butler-platform-admin"},
+			wantAtLogin:     RoleViewer,
+			wantAtRefresh:   RoleAdmin,
+		},
+		{
+			name:            "user downgraded from admin to viewer group",
+			groupsAtLogin:   []string{"butler-platform-admin"},
+			groupsAtRefresh: []string{"butler-platform-viewers"},
+			wantAtLogin:     RoleAdmin,
+			wantAtRefresh:   RoleViewer,
+		},
+		{
+			name:               "CRD admin preserved even if removed from group",
+			groupsAtLogin:      []string{"butler-platform-admin"},
+			groupsAtRefresh:    []string{"unrelated-group"},
+			crdIsPlatformAdmin: true,
+			wantAtLogin:        RoleAdmin,
+			wantAtRefresh:      RoleAdmin, // CRD override stays
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate login
+			loginGroupRole := ResolvePlatformRole(tt.groupsAtLogin, platformRoleGroups)
+			loginEffective := EffectivePlatformRole(tt.crdPlatformRole, tt.crdIsPlatformAdmin, loginGroupRole)
+			if loginEffective != tt.wantAtLogin {
+				t.Errorf("at login: effective = %q, want %q", loginEffective, tt.wantAtLogin)
+			}
+
+			// Simulate refresh with changed groups
+			refreshGroupRole := ResolvePlatformRole(tt.groupsAtRefresh, platformRoleGroups)
+			refreshEffective := EffectivePlatformRole(tt.crdPlatformRole, tt.crdIsPlatformAdmin, refreshGroupRole)
+			if refreshEffective != tt.wantAtRefresh {
+				t.Errorf("at refresh: effective = %q, want %q", refreshEffective, tt.wantAtRefresh)
+			}
+		})
+	}
+}
+
 func TestMatchGroup(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -67,6 +67,7 @@ type UserInfo struct {
 	AuthType        string
 	SSOProvider     string
 	IsPlatformAdmin bool
+	PlatformRole    string
 }
 
 // UserService handles user management operations using User CRDs.
@@ -670,6 +671,7 @@ func (s *UserService) userFromUnstructured(u *unstructured.Unstructured) *UserIn
 	authType, _, _ := unstructured.NestedString(u.Object, "spec", "authType")
 	ssoProvider, _, _ := unstructured.NestedString(u.Object, "spec", "ssoProvider")
 	isPlatformAdmin, _, _ := unstructured.NestedBool(u.Object, "spec", "isPlatformAdmin")
+	platformRole, _, _ := unstructured.NestedString(u.Object, "spec", "platformRole")
 	phase, _, _ := unstructured.NestedString(u.Object, "status", "phase")
 
 	if authType == "" {
@@ -689,6 +691,7 @@ func (s *UserService) userFromUnstructured(u *unstructured.Unstructured) *UserIn
 		AuthType:        authType,
 		SSOProvider:     ssoProvider,
 		IsPlatformAdmin: isPlatformAdmin,
+		PlatformRole:    platformRole,
 	}
 }
 

--- a/internal/websocket/auth.go
+++ b/internal/websocket/auth.go
@@ -61,7 +61,7 @@ func requireSession(w http.ResponseWriter, r *http.Request, resolver SessionReso
 // true when the session is a platform admin; otherwise writes HTTP 403 and
 // returns false.
 func requirePlatformAdmin(w http.ResponseWriter, r *http.Request, session *SessionInfo, log *slog.Logger) bool {
-	if session.IsPlatformAdmin {
+	if session.PlatformRole == "admin" {
 		return true
 	}
 	log.Warn("WebSocket upgrade rejected",
@@ -82,7 +82,7 @@ func requirePlatformAdmin(w http.ResponseWriter, r *http.Request, session *Sessi
 // path param on tenant-terminal endpoints), which in butler-server's
 // model equals the team namespace that the controller reconciles.
 func requireTeamAccess(w http.ResponseWriter, r *http.Request, session *SessionInfo, team string, log *slog.Logger) bool {
-	if session.IsPlatformAdmin {
+	if session.PlatformRole == "admin" || session.PlatformRole == "viewer" {
 		return true
 	}
 	for _, tm := range session.Teams {

--- a/internal/websocket/auth_test.go
+++ b/internal/websocket/auth_test.go
@@ -85,7 +85,7 @@ func TestRequireSession_ResolverNilSession_401(t *testing.T) {
 }
 
 func TestRequireSession_Valid_ReturnsSession(t *testing.T) {
-	want := &SessionInfo{IsPlatformAdmin: true}
+	want := &SessionInfo{PlatformRole: "admin", IsPlatformAdmin: true}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/ws/clusters", nil)
 	resolver := func(_ *http.Request) (*SessionInfo, error) {

--- a/internal/websocket/auth_test.go
+++ b/internal/websocket/auth_test.go
@@ -115,7 +115,7 @@ func TestRequirePlatformAdmin_NonAdmin_403(t *testing.T) {
 func TestRequirePlatformAdmin_Admin_Pass(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/ws/terminal/management", nil)
-	ok := requirePlatformAdmin(rec, req, &SessionInfo{IsPlatformAdmin: true}, newTestLogger())
+	ok := requirePlatformAdmin(rec, req, &SessionInfo{PlatformRole: "admin"}, newTestLogger())
 	if !ok {
 		t.Fatal("expected true for platform admin")
 	}
@@ -127,7 +127,7 @@ func TestRequirePlatformAdmin_Admin_Pass(t *testing.T) {
 func TestRequireTeamAccess_PlatformAdminBypasses(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/ws/terminal/tenant/acme/c1", nil)
-	ok := requireTeamAccess(rec, req, &SessionInfo{IsPlatformAdmin: true}, "acme", newTestLogger())
+	ok := requireTeamAccess(rec, req, &SessionInfo{PlatformRole: "admin"}, "acme", newTestLogger())
 	if !ok {
 		t.Fatal("platform admin should bypass team check")
 	}
@@ -166,6 +166,40 @@ func TestRequireTeamAccess_EmptyTeams_403(t *testing.T) {
 	}
 	if rec.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}
+
+// Platform viewer tests for WebSocket auth gates.
+
+func TestRequirePlatformAdmin_Viewer_403(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ws/terminal/management", nil)
+	ok := requirePlatformAdmin(rec, req, &SessionInfo{PlatformRole: "viewer", Email: "viewer@co.com"}, newTestLogger())
+	if ok {
+		t.Fatal("platform viewer must NOT pass requirePlatformAdmin (management terminal)")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestRequireTeamAccess_ViewerBypasses(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ws/terminal/tenant/acme/c1", nil)
+	session := &SessionInfo{PlatformRole: "viewer", Email: "viewer@co.com"}
+	ok := requireTeamAccess(rec, req, session, "acme", newTestLogger())
+	if !ok {
+		t.Fatal("platform viewer should bypass team access check")
+	}
+}
+
+func TestRequireTeamAccess_ViewerBypassesWithNoTeams(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ws/terminal/tenant/acme/c1", nil)
+	session := &SessionInfo{PlatformRole: "viewer", Email: "viewer@co.com", Teams: nil}
+	ok := requireTeamAccess(rec, req, session, "acme", newTestLogger())
+	if !ok {
+		t.Fatal("platform viewer with empty teams list should still bypass team access check")
 	}
 }
 

--- a/internal/websocket/hub.go
+++ b/internal/websocket/hub.go
@@ -98,6 +98,7 @@ type ResourceRef struct {
 type SessionInfo struct {
 	Email           string
 	IsPlatformAdmin bool
+	PlatformRole    string
 	Teams           []TeamInfo
 }
 
@@ -413,7 +414,7 @@ func (h *Hub) HandleClusterWatch(w http.ResponseWriter, r *http.Request) {
 		conn:            conn,
 		send:            make(chan Message, 256),
 		teams:           teams,
-		isPlatformAdmin: session.IsPlatformAdmin,
+		isPlatformAdmin: session.PlatformRole == "admin",
 	}
 
 	h.register <- client


### PR DESCRIPTION
## Summary

- Computes effective PlatformRole at session creation in all auth paths (OIDC callback, internal user login, device flow, legacy admin) using `max(CRD platformRole, isPlatformAdmin, IdP group match)`
- Loads `platformRoleGroups` from IdentityProvider CRDs at startup via `LoadAllPlatformRoleGroups`
- Updates `SessionMiddleware` to check `PlatformRole` instead of `IsPlatformAdmin`; platform viewers bypass the "no team access" gate but do not get the admin fast path (no impersonation)
- Adds `RequirePlatformViewer()` middleware for read-only platform-wide endpoints
- `RequireTeam` and `ClusterTeamAuthz` allow both admin and viewer roles through
- WebSocket: `requirePlatformAdmin` remains admin-only (management terminal), `requireTeamAccess` now allows viewers for tenant endpoints
- `RefreshPermissions` re-evaluates group membership against IdP config on each call
- API responses include both `isPlatformAdmin` (backwards compat) and `platformRole`

## Test plan

- [x] `go test ./... -count=1` passes (all packages)
- [x] `go build ./...` and `go vet ./...` clean
- [x] Login scenario tests: admin group, viewer group, both groups, CRD-only admin, CRD-only viewer, no role
- [x] Multi-IdP isolation: Entra group not matched against Google config and vice versa
- [x] RefreshPermissions role change: group removal downgrades, group addition upgrades, CRD override preserved
- [x] Middleware tests: `RequirePlatformViewer` passes viewer/admin, blocks regular user; `RequirePlatformAdmin` blocks viewer
- [x] WebSocket tests: viewer blocked from management terminal, passes team access check
- [x] Backwards compat: `IsPlatformAdmin` computed from PlatformRole in session and API responses