### PR TITLE
Bump butler-api to v0.15.0, surface iconData and tier in addon API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-server
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.14.0
+	github.com/butlerdotdev/butler-api v0.15.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creack/pty v1.1.9
 	github.com/go-chi/chi/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/butlerdotdev/butler-api v0.14.0 h1:PR6J0eYB7/6Mk5AbPSRSubaNhQZJj1lL2YDdkbVWsKQ=
-github.com/butlerdotdev/butler-api v0.14.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.15.0 h1:re+6YTS/CbBspGPK2Z6BO/OxNVXZHemOWqZ/pIE4s2U=
+github.com/butlerdotdev/butler-api v0.15.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/internal/api/handlers/addons.go
+++ b/internal/api/handlers/addons.go
@@ -53,6 +53,8 @@ type AddonDefinitionResponse struct {
 	Description       string            `json:"description"`
 	Category          string            `json:"category"`
 	Icon              string            `json:"icon,omitempty"`
+	IconData          string            `json:"iconData,omitempty"`
+	Tier              string            `json:"tier,omitempty"`
 	ChartRepository   string            `json:"chartRepository"`
 	ChartName         string            `json:"chartName"`
 	DefaultVersion    string            `json:"defaultVersion"`
@@ -695,6 +697,8 @@ func (h *AddonsHandler) addonDefinitionToResponse(ad *unstructured.Unstructured)
 	description, _ := spec["description"].(string)
 	category, _ := spec["category"].(string)
 	icon, _ := spec["icon"].(string)
+	iconData, _ := spec["iconData"].(string)
+	tier, _ := spec["tier"].(string)
 	platform, _ := spec["platform"].(bool)
 
 	chartSpec, _ := spec["chart"].(map[string]interface{})
@@ -744,6 +748,8 @@ func (h *AddonsHandler) addonDefinitionToResponse(ad *unstructured.Unstructured)
 		Description:       description,
 		Category:          category,
 		Icon:              icon,
+		IconData:          iconData,
+		Tier:              tier,
 		ChartRepository:   chartRepo,
 		ChartName:         chartName,
 		DefaultVersion:    defaultVersion,
@@ -857,6 +863,8 @@ type CreateAddonDefinitionRequest struct {
 	Description      string            `json:"description"`
 	Category         string            `json:"category"`
 	Icon             string            `json:"icon,omitempty"`
+	IconData         string            `json:"iconData,omitempty"`
+	Tier             string            `json:"tier,omitempty"`
 	ChartRepository  string            `json:"chartRepository"`
 	ChartName        string            `json:"chartName"`
 	DefaultVersion   string            `json:"defaultVersion"`
@@ -914,6 +922,12 @@ func (h *AddonsHandler) CreateAddonDefinition(w http.ResponseWriter, r *http.Req
 	}
 	if req.Icon != "" {
 		spec["icon"] = req.Icon
+	}
+	if req.IconData != "" {
+		spec["iconData"] = req.IconData
+	}
+	if req.Tier != "" {
+		spec["tier"] = req.Tier
 	}
 	if req.DefaultNamespace != "" {
 		spec["defaults"] = map[string]interface{}{
@@ -989,6 +1003,12 @@ func (h *AddonsHandler) UpdateAddonDefinition(w http.ResponseWriter, r *http.Req
 	}
 	if req.Icon != "" {
 		spec["icon"] = req.Icon
+	}
+	if req.IconData != "" {
+		spec["iconData"] = req.IconData
+	}
+	if req.Tier != "" {
+		spec["tier"] = req.Tier
 	}
 	spec["platform"] = req.Platform
 


### PR DESCRIPTION
## Context

PR 2 of the iconData cross-repo chain (butlerdotdev/butler-api#37). Bumps butler-api to v0.15.0 to pick up the `IconData` field added to `AddonDefinitionSpec` in butlerdotdev/butler-api#38.

butler-server uses explicit response DTOs and field mapping for addon definitions — new CRD fields don't surface automatically. This PR adds `iconData` and `tier` to the serialization path so the console can read them from API responses.

The `tier` field was already present on the CRD since butler-api v0.14.0 (#35) but was never added to the server's response types. Both fields are included here since they share the same mapping pattern.

## Changes

- Bump `butler-api` dependency: v0.14.0 -> v0.15.0
- Add `IconData` and `Tier` to `AddonDefinitionResponse` struct
- Add `IconData` and `Tier` to `CreateAddonDefinitionRequest` struct
- Extract `iconData` and `tier` in `addonDefinitionToResponse()` mapping function
- Pass `iconData` and `tier` through in `CreateAddonDefinition()` and `UpdateAddonDefinition()`

All changes in `internal/api/handlers/addons.go`.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all handler tests green)
- [x] No changes to unrelated response types

## Dependency chain

1. butlerdotdev/butler-api#38 — merged, tagged v0.15.0
2. **This PR**
3. butlerdotdev/butler-charts — populate iconData on all 27 addons (separate PR)
4. butlerdotdev/butler-console#58 — update AddonIcon to read iconData

Tracked in butlerdotdev/butler-api#37.