### PR TITLE
feat: add auth checks to ungated mutation handlers

### DIFF
--- a/internal/api/handlers/addons.go
+++ b/internal/api/handlers/addons.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/butlerdotdev/butler-server/internal/auth"
 	"github.com/butlerdotdev/butler-server/internal/config"
 	"github.com/butlerdotdev/butler-server/internal/k8s"
 
@@ -287,6 +288,12 @@ func (h *AddonsHandler) InstallAddon(w http.ResponseWriter, r *http.Request) {
 	clusterName := chi.URLParam(r, "name")
 	ctx := r.Context()
 
+	user := auth.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
 	var req InstallAddonRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -298,9 +305,14 @@ func (h *AddonsHandler) InstallAddon(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err := h.k8sClient.GetTenantCluster(ctx, namespace, clusterName)
+	cluster, err := h.k8sClient.GetTenantCluster(ctx, namespace, clusterName)
 	if err != nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+
+	if err := h.checkOperatePermission(user, cluster, "install addons on"); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
 		return
 	}
 
@@ -432,15 +444,26 @@ func (h *AddonsHandler) UpdateAddonValues(w http.ResponseWriter, r *http.Request
 	addonName := chi.URLParam(r, "addon")
 	ctx := r.Context()
 
+	user := auth.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
 	var req UpdateAddonRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
-	_, err := h.k8sClient.GetTenantCluster(ctx, namespace, clusterName)
+	cluster, err := h.k8sClient.GetTenantCluster(ctx, namespace, clusterName)
 	if err != nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+
+	if err := h.checkOperatePermission(user, cluster, "update addons on"); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
 		return
 	}
 
@@ -484,9 +507,20 @@ func (h *AddonsHandler) UninstallAddon(w http.ResponseWriter, r *http.Request) {
 	addonName := chi.URLParam(r, "addon")
 	ctx := r.Context()
 
-	_, err := h.k8sClient.GetTenantCluster(ctx, namespace, clusterName)
+	user := auth.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	cluster, err := h.k8sClient.GetTenantCluster(ctx, namespace, clusterName)
 	if err != nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+
+	if err := h.checkOperatePermission(user, cluster, "uninstall addons from"); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
 		return
 	}
 
@@ -1089,4 +1123,31 @@ func (h *AddonsHandler) DeleteAddonDefinition(w http.ResponseWriter, r *http.Req
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"message": "addon definition deleted"})
+}
+
+// checkOperatePermission verifies the user can perform mutations on a cluster's addons.
+func (h *AddonsHandler) checkOperatePermission(user *auth.UserSession, cluster *unstructured.Unstructured, operation string) error {
+	teamRef, _, _ := unstructured.NestedString(cluster.Object, "spec", "teamRef", "name")
+
+	if user.SelectedTeam != "" {
+		if user.SelectedTeamRole == auth.RoleViewer {
+			return fmt.Errorf("viewer role cannot %s clusters", operation)
+		}
+		if teamRef != "" && teamRef != user.SelectedTeam {
+			return fmt.Errorf("cannot %s cluster for team '%s' while scoped to team '%s'", operation, teamRef, user.SelectedTeam)
+		}
+		return nil
+	}
+
+	if user.IsAdmin() {
+		return nil
+	}
+
+	if teamRef == "" {
+		return fmt.Errorf("cluster has no team reference")
+	}
+	if !user.CanOperateTeam(teamRef) {
+		return fmt.Errorf("you don't have permission to %s clusters for team '%s'", operation, teamRef)
+	}
+	return nil
 }

--- a/internal/api/handlers/auth_hardening_test.go
+++ b/internal/api/handlers/auth_hardening_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/butlerdotdev/butler-server/internal/auth"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// makeCluster creates an unstructured TenantCluster with the given teamRef.
+func makeCluster(teamRef string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{},
+	}}
+	if teamRef != "" {
+		unstructured.SetNestedField(obj.Object, teamRef, "spec", "teamRef", "name")
+	}
+	return obj
+}
+
+func TestAddonsHandler_checkOperatePermission(t *testing.T) {
+	h := &AddonsHandler{}
+	cluster := makeCluster("team-alpha")
+
+	tests := []struct {
+		name    string
+		user    *auth.UserSession
+		wantErr bool
+	}{
+		{
+			name: "platform admin allowed",
+			user: &auth.UserSession{PlatformRole: auth.RoleAdmin},
+		},
+		{
+			name:    "platform viewer denied",
+			user:    &auth.UserSession{PlatformRole: auth.RoleViewer},
+			wantErr: true,
+		},
+		{
+			name: "team operator allowed",
+			user: &auth.UserSession{
+				Teams: []auth.TeamMembership{{Name: "team-alpha", Role: auth.RoleOperator}},
+			},
+		},
+		{
+			name:    "team viewer denied",
+			user:    &auth.UserSession{PlatformRole: auth.RoleViewer},
+			wantErr: true,
+		},
+		{
+			name: "selected team operator allowed",
+			user: &auth.UserSession{
+				SelectedTeam:     "team-alpha",
+				SelectedTeamRole: auth.RoleOperator,
+			},
+		},
+		{
+			name: "selected team admin allowed",
+			user: &auth.UserSession{
+				SelectedTeam:     "team-alpha",
+				SelectedTeamRole: auth.RoleAdmin,
+			},
+		},
+		{
+			name: "selected team viewer denied",
+			user: &auth.UserSession{
+				SelectedTeam:     "team-alpha",
+				SelectedTeamRole: auth.RoleViewer,
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong team context denied",
+			user: &auth.UserSession{
+				SelectedTeam:     "team-beta",
+				SelectedTeamRole: auth.RoleOperator,
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no team membership and not admin denied",
+			user:    &auth.UserSession{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := h.checkOperatePermission(tt.user, cluster, "install addons on")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkOperatePermission() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAddonsHandler_checkOperatePermission_noTeamRef(t *testing.T) {
+	h := &AddonsHandler{}
+	cluster := makeCluster("")
+
+	tests := []struct {
+		name    string
+		user    *auth.UserSession
+		wantErr bool
+	}{
+		{
+			name: "admin allowed even without teamRef",
+			user: &auth.UserSession{PlatformRole: auth.RoleAdmin},
+		},
+		{
+			name:    "non-admin denied without teamRef",
+			user:    &auth.UserSession{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := h.checkOperatePermission(tt.user, cluster, "install addons on")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkOperatePermission() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGitOpsHandler_checkOperatePermission(t *testing.T) {
+	h := &GitOpsHandler{}
+	cluster := makeCluster("team-alpha")
+
+	tests := []struct {
+		name    string
+		user    *auth.UserSession
+		wantErr bool
+	}{
+		{
+			name: "platform admin allowed",
+			user: &auth.UserSession{PlatformRole: auth.RoleAdmin},
+		},
+		{
+			name:    "platform viewer denied",
+			user:    &auth.UserSession{PlatformRole: auth.RoleViewer},
+			wantErr: true,
+		},
+		{
+			name: "team operator allowed",
+			user: &auth.UserSession{
+				Teams: []auth.TeamMembership{{Name: "team-alpha", Role: auth.RoleOperator}},
+			},
+		},
+		{
+			name: "selected team operator allowed",
+			user: &auth.UserSession{
+				SelectedTeam:     "team-alpha",
+				SelectedTeamRole: auth.RoleOperator,
+			},
+		},
+		{
+			name: "selected team viewer denied",
+			user: &auth.UserSession{
+				SelectedTeam:     "team-alpha",
+				SelectedTeamRole: auth.RoleViewer,
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong team context denied",
+			user: &auth.UserSession{
+				SelectedTeam:     "team-beta",
+				SelectedTeamRole: auth.RoleAdmin,
+			},
+			wantErr: true,
+		},
+		{
+			name:    "unauthenticated denied",
+			user:    &auth.UserSession{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := h.checkOperatePermission(tt.user, cluster, "enable GitOps on")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkOperatePermission() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckTemplatePermission(t *testing.T) {
+	tests := []struct {
+		name      string
+		user      *auth.UserSession
+		namespace string
+		wantErr   bool
+	}{
+		{
+			name:      "admin can modify cluster-scoped templates",
+			user:      &auth.UserSession{PlatformRole: auth.RoleAdmin},
+			namespace: "butler-system",
+		},
+		{
+			name:      "viewer cannot modify cluster-scoped templates",
+			user:      &auth.UserSession{PlatformRole: auth.RoleViewer},
+			namespace: "butler-system",
+			wantErr:   true,
+		},
+		{
+			name:      "non-admin cannot modify cluster-scoped templates",
+			user:      &auth.UserSession{},
+			namespace: "butler-system",
+			wantErr:   true,
+		},
+		{
+			name: "team operator can modify team templates",
+			user: &auth.UserSession{
+				Teams: []auth.TeamMembership{{Name: "alpha", Role: auth.RoleOperator}},
+			},
+			namespace: "team-alpha",
+		},
+		{
+			name: "team admin can modify team templates",
+			user: &auth.UserSession{
+				Teams: []auth.TeamMembership{{Name: "alpha", Role: auth.RoleAdmin}},
+			},
+			namespace: "team-alpha",
+		},
+		{
+			name: "team viewer cannot modify team templates",
+			user: &auth.UserSession{
+				Teams: []auth.TeamMembership{{Name: "alpha", Role: auth.RoleViewer}},
+			},
+			namespace: "team-alpha",
+			wantErr:   true,
+		},
+		{
+			name:      "platform admin can modify any team templates",
+			user:      &auth.UserSession{PlatformRole: auth.RoleAdmin},
+			namespace: "team-alpha",
+		},
+		{
+			name:      "platform viewer cannot modify team templates",
+			user:      &auth.UserSession{PlatformRole: auth.RoleViewer},
+			namespace: "team-alpha",
+			wantErr:   true,
+		},
+		{
+			name: "wrong team denied",
+			user: &auth.UserSession{
+				Teams: []auth.TeamMembership{{Name: "beta", Role: auth.RoleAdmin}},
+			},
+			namespace: "team-alpha",
+			wantErr:   true,
+		},
+		{
+			name:      "unknown namespace requires admin",
+			user:      &auth.UserSession{PlatformRole: auth.RoleAdmin},
+			namespace: "custom-ns",
+		},
+		{
+			name:      "unknown namespace denied for non-admin",
+			user:      &auth.UserSession{},
+			namespace: "custom-ns",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkTemplatePermission(tt.user, tt.namespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkTemplatePermission(%q) error = %v, wantErr %v", tt.namespace, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/gitops.go
+++ b/internal/api/handlers/gitops.go
@@ -28,10 +28,12 @@ import (
 	"strings"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"github.com/butlerdotdev/butler-server/internal/auth"
 	"github.com/butlerdotdev/butler-server/internal/config"
 	"github.com/butlerdotdev/butler-server/internal/gitops"
 	"github.com/butlerdotdev/butler-server/internal/k8s"
 	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // GitOpsHandler handles GitOps-related API requests.
@@ -236,6 +238,22 @@ func (h *GitOpsHandler) EnableGitOps(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
+
+	user := auth.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	cluster, err := h.k8sClient.GetTenantCluster(ctx, namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+	if err := h.checkOperatePermission(user, cluster, "enable GitOps on"); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
 	var req gitops.EnableGitOpsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -483,6 +501,22 @@ func (h *GitOpsHandler) DisableGitOps(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
+	user := auth.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	cluster, err := h.k8sClient.GetTenantCluster(ctx, namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+	if err := h.checkOperatePermission(user, cluster, "disable GitOps on"); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
+
 	h.logger.Info("Disabling GitOps on cluster",
 		"namespace", namespace,
 		"name", name,
@@ -532,6 +566,22 @@ func (h *GitOpsHandler) ExportAddon(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
+
+	user := auth.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	cluster, err := h.k8sClient.GetTenantCluster(ctx, namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+	if err := h.checkOperatePermission(user, cluster, "export addons from"); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
 	var req gitops.ExportAddonRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -739,6 +789,22 @@ func (h *GitOpsHandler) ExportRelease(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
+
+	user := auth.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	cluster, err := h.k8sClient.GetTenantCluster(ctx, namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+	if err := h.checkOperatePermission(user, cluster, "export releases from"); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
 	var req struct {
 		ReleaseName      string `json:"releaseName"`
@@ -955,6 +1021,22 @@ func (h *GitOpsHandler) ExportAllAddons(w http.ResponseWriter, r *http.Request) 
 	ctx := r.Context()
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
+
+	user := auth.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	cluster, err := h.k8sClient.GetTenantCluster(ctx, namespace, name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("cluster not found: %v", err))
+		return
+	}
+	if err := h.checkOperatePermission(user, cluster, "migrate addons on"); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
 	var req gitops.MigrateToGitOpsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -2187,4 +2269,31 @@ func stripDuplicateNamespace(manifests map[string][]byte) {
 		b.WriteByte('\n')
 	}
 	manifests["kustomization.yaml"] = []byte(b.String())
+}
+
+// checkOperatePermission verifies the user can perform mutations on a cluster's GitOps config.
+func (h *GitOpsHandler) checkOperatePermission(user *auth.UserSession, cluster *unstructured.Unstructured, operation string) error {
+	teamRef, _, _ := unstructured.NestedString(cluster.Object, "spec", "teamRef", "name")
+
+	if user.SelectedTeam != "" {
+		if user.SelectedTeamRole == auth.RoleViewer {
+			return fmt.Errorf("viewer role cannot %s clusters", operation)
+		}
+		if teamRef != "" && teamRef != user.SelectedTeam {
+			return fmt.Errorf("cannot %s cluster for team '%s' while scoped to team '%s'", operation, teamRef, user.SelectedTeam)
+		}
+		return nil
+	}
+
+	if user.IsAdmin() {
+		return nil
+	}
+
+	if teamRef == "" {
+		return fmt.Errorf("cluster has no team reference")
+	}
+	if !user.CanOperateTeam(teamRef) {
+		return fmt.Errorf("you don't have permission to %s clusters for team '%s'", operation, teamRef)
+	}
+	return nil
 }

--- a/internal/api/handlers/providers.go
+++ b/internal/api/handlers/providers.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/butlerdotdev/butler-server/internal/auth"
 	"github.com/butlerdotdev/butler-server/internal/certificates"
 	"github.com/butlerdotdev/butler-server/internal/config"
 	"github.com/butlerdotdev/butler-server/internal/k8s"
@@ -1014,6 +1015,16 @@ func (h *ProvidersHandler) ListTeamProviders(w http.ResponseWriter, r *http.Requ
 func (h *ProvidersHandler) CreateTeamProvider(w http.ResponseWriter, r *http.Request) {
 	teamName := chi.URLParam(r, "name")
 
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if !user.CanOperateTeam(teamName) {
+		writeError(w, http.StatusForbidden, fmt.Sprintf("you don't have permission to manage providers for team '%s'", teamName))
+		return
+	}
+
 	var req CreateProviderRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -1034,6 +1045,16 @@ func (h *ProvidersHandler) DeleteTeamProvider(w http.ResponseWriter, r *http.Req
 	namespace := chi.URLParam(r, "namespace")
 	providerName := chi.URLParam(r, "providerName")
 	ctx := r.Context()
+
+	user := auth.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if !user.CanOperateTeam(teamName) {
+		writeError(w, http.StatusForbidden, fmt.Sprintf("you don't have permission to manage providers for team '%s'", teamName))
+		return
+	}
 
 	// Get provider and verify it is team-scoped to this team
 	provider, err := h.k8sClient.GetProviderConfig(ctx, namespace, providerName)

--- a/internal/api/handlers/workspaces.go
+++ b/internal/api/handlers/workspaces.go
@@ -771,6 +771,16 @@ func (h *WorkspaceHandler) UpdateTemplate(w http.ResponseWriter, r *http.Request
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if err := checkTemplatePermission(user, namespace); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
+
 	var body map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -819,12 +829,49 @@ func (h *WorkspaceHandler) DeleteTemplate(w http.ResponseWriter, r *http.Request
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if err := checkTemplatePermission(user, namespace); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
+
 	if err := h.k8sClient.Dynamic().Resource(WorkspaceTemplateGVR).Namespace(namespace).Delete(r.Context(), name, metav1.DeleteOptions{}); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to delete template: %v", err))
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+// checkTemplatePermission verifies the user can mutate workspace templates
+// in the given namespace. Cluster-scoped templates (butler-system) require
+// platform admin. Team-scoped templates require team operator.
+func checkTemplatePermission(user *auth.UserSession, namespace string) error {
+	if namespace == "butler-system" {
+		if !user.IsAdmin() {
+			return fmt.Errorf("only platform admins can modify cluster-scoped templates")
+		}
+		return nil
+	}
+
+	// Team-scoped: namespace is "team-{name}"
+	if strings.HasPrefix(namespace, "team-") {
+		teamName := strings.TrimPrefix(namespace, "team-")
+		if !user.CanOperateTeam(teamName) {
+			return fmt.Errorf("you don't have permission to modify templates for team '%s'", teamName)
+		}
+		return nil
+	}
+
+	// Unknown namespace pattern — require admin as a safe default
+	if !user.IsAdmin() {
+		return fmt.Errorf("insufficient permissions to modify templates in namespace '%s'", namespace)
+	}
+	return nil
 }
 
 // ---- Metrics ----

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -296,21 +296,31 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			r.Get("/management/nodes", clusterHandler.GetManagementNodes)
 			r.Get("/management/pods/{namespace}", clusterHandler.GetManagementPods)
 
-			// Management addons
+			// Management addons (reads)
 			r.Get("/management/addons", addonsHandler.ListManagementAddons)
-			r.Post("/management/addons", addonsHandler.InstallManagementAddon)
 			r.Get("/management/addons/{name}", addonsHandler.GetManagementAddon)
-			r.Put("/management/addons/{name}", addonsHandler.UpdateManagementAddon)
-			r.Delete("/management/addons/{name}", addonsHandler.UninstallManagementAddon)
 
-			// Management GitOps
+			// Management addons (mutations - admin only)
+			r.Group(func(r chi.Router) {
+				r.Use(adminMiddleware)
+				r.Post("/management/addons", addonsHandler.InstallManagementAddon)
+				r.Put("/management/addons/{name}", addonsHandler.UpdateManagementAddon)
+				r.Delete("/management/addons/{name}", addonsHandler.UninstallManagementAddon)
+			})
+
+			// Management GitOps (reads)
 			r.Get("/management/gitops/status", gitopsHandler.GetManagementStatus)
-			r.Post("/management/gitops/enable", gitopsHandler.EnableManagementGitOps)
-			r.Delete("/management/gitops", gitopsHandler.DisableManagementGitOps)
 			r.Get("/management/gitops/discover", gitopsHandler.DiscoverManagementReleases)
-			r.Post("/management/gitops/export", gitopsHandler.ExportManagementAddon)
-			r.Post("/management/gitops/export-catalog", gitopsHandler.ExportManagementCatalogAddon)
-			r.Post("/management/gitops/migrate", gitopsHandler.ExportAllManagementAddons)
+
+			// Management GitOps (mutations - admin only)
+			r.Group(func(r chi.Router) {
+				r.Use(adminMiddleware)
+				r.Post("/management/gitops/enable", gitopsHandler.EnableManagementGitOps)
+				r.Delete("/management/gitops", gitopsHandler.DisableManagementGitOps)
+				r.Post("/management/gitops/export", gitopsHandler.ExportManagementAddon)
+				r.Post("/management/gitops/export-catalog", gitopsHandler.ExportManagementCatalogAddon)
+				r.Post("/management/gitops/migrate", gitopsHandler.ExportAllManagementAddons)
+			})
 
 			// Steward: TenantControlPlane and DataStore visibility
 			r.Get("/management/tenantcontrolplanes", stewardHandler.ListTenantControlPlanes)
@@ -349,10 +359,15 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			// GitOps global configuration (Git provider setup)
 			r.Route("/gitops", func(r chi.Router) {
 				r.Get("/config", gitopsHandler.GetConfig)
-				r.Post("/config", gitopsHandler.SaveConfig)
 				r.Get("/repos", gitopsHandler.ListRepositories)
 				r.Get("/repos/branches", gitopsHandler.ListBranches)
-				r.Post("/preview", gitopsHandler.PreviewManifest)
+
+				// Mutations require admin (credentials and manifest generation)
+				r.Group(func(r chi.Router) {
+					r.Use(adminMiddleware)
+					r.Post("/config", gitopsHandler.SaveConfig)
+					r.Post("/preview", gitopsHandler.PreviewManifest)
+				})
 			})
 
 			// Cluster GitOps
@@ -411,19 +426,24 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 			r.Get("/image-factory/catalog", imagesHandler.GetFactoryCatalog)
 			r.Get("/image-factory/schematics/{id}", imagesHandler.GetFactorySchematic)
 
-			// Providers
+			// Providers (reads)
 			r.Get("/providers", providerHandler.List)
-			r.Post("/providers", providerHandler.Create)
-			r.Post("/providers/test", providerHandler.TestConnection)
 			r.Get("/providers/{namespace}/{name}/images", providerHandler.ListImages)
 			r.Get("/providers/{namespace}/{name}/networks", providerHandler.ListNetworks)
 			r.Get("/providers/{namespace}/{name}/clusters", providerHandler.ListClusters)
 			r.Get("/providers/{namespace}/{name}/storage-containers", providerHandler.ListStorageContainers)
 			r.Get("/providers/{namespace}/{name}", providerHandler.Get)
-			r.Put("/providers/{namespace}/{name}", providerHandler.Update)
-			r.Delete("/providers/{namespace}/{name}", providerHandler.Delete)
-			r.Post("/providers/{namespace}/{name}/validate", providerHandler.Validate)
 			r.Get("/providers/{namespace}/{name}/ca-info", providerHandler.GetCAInfo)
+
+			// Provider mutations (admin only - credentials are sensitive)
+			r.Group(func(r chi.Router) {
+				r.Use(adminMiddleware)
+				r.Post("/providers", providerHandler.Create)
+				r.Post("/providers/test", providerHandler.TestConnection)
+				r.Put("/providers/{namespace}/{name}", providerHandler.Update)
+				r.Delete("/providers/{namespace}/{name}", providerHandler.Delete)
+				r.Post("/providers/{namespace}/{name}/validate", providerHandler.Validate)
+			})
 
 			// Teams
 			r.Get("/teams", teamHandler.List)


### PR DESCRIPTION
## Summary

- Adds server-side authorization to 27 mutation handlers across 5 files that previously allowed any authenticated user to mutate resources without role checks
- Router-level gating (adminMiddleware) for 15 management/platform mutations: management addons, management GitOps, global GitOps config, and platform provider CRUD
- Handler-level gating (checkOperatePermission) for 12 team-scoped mutations: tenant addon install/update/uninstall, tenant GitOps enable/disable/export, team provider create/delete, workspace template update/delete
- Follows existing patterns from ClusterHandler.checkOperatePermission and CreateTemplate — no new abstractions

## Context

Surfaced during Phase 1 audit of the platform viewer deploy plan. These gaps predate the viewer feature but should ship as part of the same coordinated release.

## Test plan

- [ ] Existing handler tests pass (verified: `go test ./internal/api/handlers/` green)
- [ ] New auth_hardening_test.go covers helper functions against admin/operator/viewer/unauthenticated users (22 test cases, all pass)
- [ ] Platform admin can still perform all mutations (regression)
- [ ] Team operator can still install addons, enable GitOps, manage team providers on their cluster
- [ ] Team viewer and platform viewer get 403 on all mutation endpoints
- [ ] Unauthenticated requests get 401