### PR TITLE
fix(addons): add Addon field to InstalledAddonResponse

### DIFF
--- a/internal/api/handlers/addons.go
+++ b/internal/api/handlers/addons.go
@@ -82,8 +82,18 @@ type CategoryInfo struct {
 }
 
 // InstalledAddonResponse represents an installed addon's status.
+//
+// Name is the K8s metadata name (used for CRUD operations like uninstall).
+// Addon is the AddonDefinition name (the canonical addon identifier for
+// matching, display, and policy decisions).
+//
+// For auto-enrolled TenantAddons, Name follows the pattern <cluster>-<addon>
+// (e.g., "obs-perf-dev-vector-agent") and Addon is the AddonDefinition name
+// (e.g., "vector-agent"). For manually-named TenantAddons, Name and Addon
+// may differ arbitrarily.
 type InstalledAddonResponse struct {
 	Name             string                 `json:"name"`
+	Addon            string                 `json:"addon,omitempty"`
 	DisplayName      string                 `json:"displayName,omitempty"`
 	Status           string                 `json:"status"`
 	Phase            string                 `json:"phase,omitempty"`
@@ -263,6 +273,7 @@ func (h *AddonsHandler) ListClusterAddons(w http.ResponseWriter, r *http.Request
 
 			addons = append(addons, InstalledAddonResponse{
 				Name:        addonName,
+				Addon:       addonName,
 				DisplayName: displayName,
 				Status:      MapAddonStatus(status),
 				Version:     version,
@@ -845,6 +856,7 @@ func (h *AddonsHandler) tenantAddonToResponse(ctx context.Context, ta *unstructu
 
 	return InstalledAddonResponse{
 		Name:             name,
+		Addon:            addonName,
 		DisplayName:      displayName,
 		Status:           MapAddonStatus(phase),
 		Phase:            phase,

--- a/internal/api/handlers/addons_test.go
+++ b/internal/api/handlers/addons_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// InstalledAddonResponse JSON contract tests.
+//
+// These verify the API shape that butler-console and other consumers
+// depend on. The Addon field was added to distinguish the canonical
+// AddonDefinition name from the K8s metadata name, which differ for
+// auto-enrolled TenantAddons.
+
+func TestInstalledAddonResponse_AutoEnrolled(t *testing.T) {
+	// Auto-enrolled TenantAddons have metadata names like <cluster>-<addon>
+	// but spec.addon is the canonical AddonDefinition name.
+	resp := InstalledAddonResponse{
+		Name:      "obs-perf-dev-vector-agent",
+		Addon:     "vector-agent",
+		Status:    "installed",
+		ManagedBy: "butler",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded["name"] != "obs-perf-dev-vector-agent" {
+		t.Errorf("name = %q, want %q", decoded["name"], "obs-perf-dev-vector-agent")
+	}
+	if decoded["addon"] != "vector-agent" {
+		t.Errorf("addon = %q, want %q", decoded["addon"], "vector-agent")
+	}
+}
+
+func TestInstalledAddonResponse_ManuallyNamed(t *testing.T) {
+	// Manually-created TenantAddons can have any metadata name.
+	// Addon still reflects the AddonDefinition name from spec.addon.
+	resp := InstalledAddonResponse{
+		Name:      "my-custom-name",
+		Addon:     "vector-agent",
+		Status:    "installed",
+		ManagedBy: "butler",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded["name"] != "my-custom-name" {
+		t.Errorf("name = %q, want %q", decoded["name"], "my-custom-name")
+	}
+	if decoded["addon"] != "vector-agent" {
+		t.Errorf("addon = %q, want %q", decoded["addon"], "vector-agent")
+	}
+}
+
+func TestInstalledAddonResponse_BackwardsCompat(t *testing.T) {
+	// Existing consumers that only read the Name field should be unaffected.
+	// When Addon is empty, omitempty ensures it's absent from the JSON.
+	resp := InstalledAddonResponse{
+		Name:   "vector-agent",
+		Status: "installed",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded["name"] != "vector-agent" {
+		t.Errorf("name = %q, want %q", decoded["name"], "vector-agent")
+	}
+	if _, exists := decoded["addon"]; exists {
+		t.Error("addon field should be omitted when empty")
+	}
+}
+
+func TestInstalledAddonResponse_PlatformManaged(t *testing.T) {
+	// Platform-managed addons from observedState have Name == Addon.
+	resp := InstalledAddonResponse{
+		Name:      "cilium",
+		Addon:     "cilium",
+		Status:    "installed",
+		ManagedBy: "platform",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded["name"] != "cilium" {
+		t.Errorf("name = %q, want %q", decoded["name"], "cilium")
+	}
+	if decoded["addon"] != "cilium" {
+		t.Errorf("addon = %q, want %q", decoded["addon"], "cilium")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Addon` field to `InstalledAddonResponse` alongside `Name`, following the `ManagementAddonResponse` pattern already established
- `Name` remains the K8s metadata name (used for CRUD operations like uninstall)
- `Addon` is the AddonDefinition name (the canonical addon identifier for matching, display, and policy decisions)
- Populated in both the TenantAddon response path and the platform-managed (observedState) addon path
- Additive change; existing consumers reading only `Name` continue working unchanged

## Context

Auto-enrolled TenantAddons have metadata names following the pattern `<cluster>-<addon>` (e.g., `obs-perf-dev-vector-agent`). butler-console's ObservabilityTab matches against patterns like `vector-agent` or `vector-agent-*`, so the auto-enrolled name never matches. This causes the console to display "Not installed" despite the addon running on the tenant cluster.

The fix adds the canonical AddonDefinition name as a separate field so consumers can match against it without heuristic pattern matching on the metadata name.

## Deployment dependency

butler-console will need a follow-up PR to match against the `addon` field instead of `name`. The console PR must deploy **after** this server change — the new field is additive, so existing console versions are unaffected until the console PR lands.

## Test plan

- [x] Unit tests for JSON contract: auto-enrolled, manually-named, backwards compat, platform-managed
- [x] Full test suite passes (`go test ./...`)
- [ ] After deploy: `curl /api/clusters/<cluster>/addons | jq '.[] | {name, addon}'` returns both fields
- [ ] Console follow-up PR updates matching logic to use `addon` field