### PR TITLE
feat(users): write lastSeenGroups at SSO login and read status.teams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-server
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.15.0
+	github.com/butlerdotdev/butler-api v0.20.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creack/pty v1.1.9
 	github.com/go-chi/chi/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/butlerdotdev/butler-api v0.15.0 h1:re+6YTS/CbBspGPK2Z6BO/OxNVXZHemOWqZ/pIE4s2U=
-github.com/butlerdotdev/butler-api v0.15.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.20.0 h1:dcDDiaejo5YN1a7ZZnsxJZhr/kDQk/IUcmPCYsT/PNA=
+github.com/butlerdotdev/butler-api v0.20.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/internal/api/handlers/auth_oidc.go
+++ b/internal/api/handlers/auth_oidc.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/butlerdotdev/butler-server/internal/audit"
@@ -167,6 +168,24 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		// This is a graceful degradation
 	} else {
 		h.logger.Info("SSO user ensured", "username", user.Name, "email", user.Email)
+
+		// Persist IdP groups to User CRD status so the butler-controller
+		// User reconciler can resolve group-based Team membership without
+		// requiring the user to be actively logged in.
+		if !groupsEqual(claims.Groups, user.LastSeenGroups) {
+			if err := h.userService.PatchLastSeenGroups(r.Context(), user.Name, claims.Groups); err != nil {
+				h.logger.Warn("Failed to patch lastSeenGroups",
+					"username", user.Name,
+					"error", err,
+				)
+			} else {
+				h.logger.Info("Updated lastSeenGroups",
+					"username", user.Name,
+					"groupCount", len(claims.Groups),
+				)
+				audit.RecordGroupSync(h.auditEmitter, claims.Email, len(claims.Groups), r.RemoteAddr)
+			}
+		}
 
 		// SECURITY: Check if user is disabled BEFORE creating session
 		if user.Disabled {
@@ -631,4 +650,30 @@ func (h *AuthHandler) createLegacyAdminSession(w http.ResponseWriter, r *http.Re
 			PlatformRole:    auth.RoleAdmin,
 		},
 	})
+}
+
+// groupsEqual compares two group slices for set equality. Sorts copies
+// of both slices before comparing so that IdP ordering changes do not
+// cause unnecessary SSA writes.
+func groupsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	aSorted := make([]string, len(a))
+	copy(aSorted, a)
+	sort.Strings(aSorted)
+
+	bSorted := make([]string, len(b))
+	copy(bSorted, b)
+	sort.Strings(bSorted)
+
+	for i := range aSorted {
+		if aSorted[i] != bSorted[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/api/handlers/users.go
+++ b/internal/api/handlers/users.go
@@ -115,8 +115,13 @@ type SetPasswordRequest struct {
 
 // ListUsers returns all users from User CRDs.
 // GET /api/users (accessible to any authenticated user)
+//
+// The User Management page shows known users (User CRDs that exist).
+// SSO users appear after first login. Users who exist only in an IdP
+// group and have never authenticated through Butler are not represented.
+// The Team detail page surfaces configured IdP group membership directly
+// and is the correct surface for the "who could access this team" question.
 func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
-	// Get all users from User CRDs
 	users, err := h.userService.ListUsers(r.Context())
 	if err != nil {
 		h.logger.Error("Failed to list users", "error", err)
@@ -124,14 +129,9 @@ func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build response with team membership info
 	response := make([]UserListResponse, 0, len(users))
-
-	// Get team membership for all users (batch lookup)
-	teamMemberships := h.teamResolver.ListAllMembers(r.Context())
-
 	for _, u := range users {
-		userResp := UserListResponse{
+		response = append(response, UserListResponse{
 			Username:        u.Name,
 			Email:           u.Email,
 			DisplayName:     u.DisplayName,
@@ -140,17 +140,10 @@ func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 			Disabled:        u.Disabled,
 			AuthType:        u.AuthType,
 			SSOProvider:     u.SSOProvider,
+			Teams:           u.Teams,
 			IsPlatformAdmin: u.IsPlatformAdmin,
 			PlatformRole:    u.PlatformRole,
-		}
-
-		// Add team membership info
-		emailLower := strings.ToLower(u.Email)
-		if membership, ok := teamMemberships[emailLower]; ok {
-			userResp.Teams = membership.Teams
-		}
-
-		response = append(response, userResp)
+		})
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -226,14 +219,6 @@ func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get team membership
-	var teams []string
-	if membership := h.teamResolver.ListAllMembers(r.Context()); membership != nil {
-		if m, ok := membership[strings.ToLower(user.Email)]; ok {
-			teams = m.Teams
-		}
-	}
-
 	writeJSON(w, http.StatusOK, UserListResponse{
 		Username:        user.Name,
 		Email:           user.Email,
@@ -243,7 +228,7 @@ func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request) {
 		Disabled:        user.Disabled,
 		AuthType:        user.AuthType,
 		SSOProvider:     user.SSOProvider,
-		Teams:           teams,
+		Teams:           user.Teams,
 		IsPlatformAdmin: user.IsPlatformAdmin,
 		PlatformRole:    user.PlatformRole,
 	})

--- a/internal/audit/auth_events.go
+++ b/internal/audit/auth_events.go
@@ -49,6 +49,23 @@ func RecordLogout(emitter *Emitter, email, sourceIP string) {
 	})
 }
 
+// RecordGroupSync records that a user's IdP groups were written to
+// the User CRD status.lastSeenGroups field.
+func RecordGroupSync(emitter *Emitter, email string, groupCount int, sourceIP string) {
+	if emitter == nil {
+		return
+	}
+	emitter.Emit(Event{
+		Timestamp:    time.Now().UTC(),
+		User:         email,
+		Action:       "group_sync",
+		ResourceType: "user",
+		Success:      true,
+		StatusCode:   200,
+		SourceIP:     sourceIP,
+	})
+}
+
 // RecordLoginFailed records a failed login attempt.
 func RecordLoginFailed(emitter *Emitter, email, provider, sourceIP, reason string) {
 	if emitter == nil {

--- a/internal/auth/teams_drift_test.go
+++ b/internal/auth/teams_drift_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/butlerdotdev/butler-api/testdata/resolution"
+)
+
+// TestResolutionDrift asserts that butler-server's resolution logic
+// produces output matching the shared fixtures in butler-api. The
+// butler-controller has an equivalent test. Drift between the two
+// implementations surfaces as a test failure in whichever component
+// diverged from the fixture expectations.
+func TestResolutionDrift(t *testing.T) {
+	fixtures := resolution.LoadAll()
+	if len(fixtures) == 0 {
+		t.Fatal("no fixtures loaded")
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.Name, func(t *testing.T) {
+			memberships := make(map[string]TeamMembership)
+
+			// Resolve manual memberships: check spec.access.users[]
+			for _, team := range f.Input.Teams {
+				for _, u := range team.Access.Users {
+					if !strings.EqualFold(u.Name, f.Input.Email) {
+						continue
+					}
+					role := u.Role
+					if role == "" {
+						role = RoleViewer
+					}
+					addMembershipForTest(memberships, team.Name, role)
+				}
+			}
+
+			// Resolve group-based memberships: check spec.access.groups[]
+			if len(f.Input.LastSeenGroups) > 0 {
+				groupSet := buildGroupLookupSet(f.Input.LastSeenGroups)
+				for _, team := range f.Input.Teams {
+					for _, g := range team.Access.Groups {
+						if !groupMatchesForTest(g.Name, groupSet) {
+							continue
+						}
+						role := g.Role
+						if role == "" {
+							role = RoleViewer
+						}
+						addMembershipForTest(memberships, team.Name, role)
+					}
+				}
+			}
+
+			// Convert to sorted slice
+			result := make([]resolution.ExpectedMembership, 0, len(memberships))
+			for _, m := range memberships {
+				result = append(result, resolution.ExpectedMembership{
+					Name: m.Name,
+					Role: m.Role,
+				})
+			}
+			sort.Slice(result, func(i, j int) bool {
+				return result[i].Name < result[j].Name
+			})
+
+			// Compare against fixture expectations
+			if len(result) != len(f.Expected) {
+				t.Fatalf("membership count: got %d, want %d\n  got:  %v\n  want: %v",
+					len(result), len(f.Expected), result, f.Expected)
+			}
+			for i := range result {
+				if result[i].Name != f.Expected[i].Name || result[i].Role != f.Expected[i].Role {
+					t.Errorf("membership[%d]: got %s(%s), want %s(%s)",
+						i, result[i].Name, result[i].Role,
+						f.Expected[i].Name, f.Expected[i].Role)
+				}
+			}
+		})
+	}
+}
+
+// addMembershipForTest mirrors the production addMembership logic using
+// the same RoleHierarchy function.
+func addMembershipForTest(memberships map[string]TeamMembership, teamName, role string) {
+	existing, ok := memberships[teamName]
+	if !ok {
+		memberships[teamName] = TeamMembership{Name: teamName, Role: role}
+		return
+	}
+	if RoleHierarchy(role, existing.Role) {
+		memberships[teamName] = TeamMembership{Name: teamName, Role: role}
+	}
+}
+
+// groupMatchesForTest mirrors the production groupMatches logic using
+// the same normalizeGroupName and buildGroupLookupSet functions.
+func groupMatchesForTest(configuredGroup string, groupSet map[string]bool) bool {
+	if groupSet[normalizeGroupName(configuredGroup)] {
+		return true
+	}
+	if groupSet[strings.ToLower(configuredGroup)] {
+		return true
+	}
+	return false
+}

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -33,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
@@ -68,6 +70,8 @@ type UserInfo struct {
 	SSOProvider     string
 	IsPlatformAdmin bool
 	PlatformRole    string
+	LastSeenGroups  []string
+	Teams           []string
 }
 
 // UserService handles user management operations using User CRDs.
@@ -279,6 +283,48 @@ func (s *UserService) EnsureSSOUser(ctx context.Context, req EnsureSSOUserReques
 	}
 
 	return s.userFromUnstructured(created), nil
+}
+
+// PatchLastSeenGroups SSA-patches status.lastSeenGroups on the User CRD.
+// Called at SSO login to persist the IdP group identifiers so the
+// butler-controller User reconciler can resolve group-based Team
+// membership without requiring the user to be actively logged in.
+//
+// Uses Server-Side Apply with field manager "butler-server/user-auth".
+// The controller's field manager ("butler-controller/user-teams") owns
+// status.teams and status.teamsResolvedAt. The two field managers do
+// not conflict because they own disjoint status fields.
+func (s *UserService) PatchLastSeenGroups(ctx context.Context, username string, groups []string) error {
+	// Normalize nil to empty slice for consistent JSON encoding.
+	// An empty lastSeenGroups means "user authenticated but IdP returned
+	// no groups" which is different from the field being absent.
+	if groups == nil {
+		groups = []string{}
+	}
+
+	patch := map[string]interface{}{
+		"apiVersion": "butler.butlerlabs.dev/v1alpha1",
+		"kind":       "User",
+		"metadata": map[string]interface{}{
+			"name": username,
+		},
+		"status": map[string]interface{}{
+			"lastSeenGroups": groups,
+		},
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshaling lastSeenGroups patch: %w", err)
+	}
+
+	_, err = s.dynamicClient.Resource(UserGVR).Patch(ctx, username, types.ApplyPatchType, patchBytes,
+		metav1.PatchOptions{
+			FieldManager: "butler-server/user-auth",
+		},
+		"status",
+	)
+	return err
 }
 
 // GetUser gets a user by username.
@@ -681,6 +727,25 @@ func (s *UserService) userFromUnstructured(u *unstructured.Unstructured) *UserIn
 		phase = "Active"
 	}
 
+	// Read status.lastSeenGroups (written by this server via SSA at login).
+	var lastSeenGroups []string
+	if rawGroups, found, _ := unstructured.NestedStringSlice(u.Object, "status", "lastSeenGroups"); found {
+		lastSeenGroups = rawGroups
+	}
+
+	// Read status.teams (written by butler-controller via SSA).
+	// Each entry is {name, role}; extract team names for the handler response.
+	var teams []string
+	if rawTeams, found, _ := unstructured.NestedSlice(u.Object, "status", "teams"); found {
+		for _, t := range rawTeams {
+			if m, ok := t.(map[string]interface{}); ok {
+				if name, _ := m["name"].(string); name != "" {
+					teams = append(teams, name)
+				}
+			}
+		}
+	}
+
 	return &UserInfo{
 		Name:            u.GetName(),
 		Email:           email,
@@ -692,6 +757,8 @@ func (s *UserService) userFromUnstructured(u *unstructured.Unstructured) *UserIn
 		SSOProvider:     ssoProvider,
 		IsPlatformAdmin: isPlatformAdmin,
 		PlatformRole:    platformRole,
+		LastSeenGroups:  lastSeenGroups,
+		Teams:           teams,
 	}
 }
 


### PR DESCRIPTION
## Summary

- SSA-patch `status.lastSeenGroups` on User CRD at SSO login (field manager: `butler-server/user-auth`)
- ListUsers/GetUser read `status.teams` from User CRDs instead of scanning Team CRDs via `ListAllMembers`
- Drift protection test against `butler-api/testdata/resolution` fixtures (13 cases)
- `RecordGroupSync` audit event on successful lastSeenGroups writes
- butler-api dependency bumped from v0.15.0 to v0.20.0

## Context

This is butler-server's role in the User-Team membership resolution arc. The butler-controller (v0.26.0) watches User and Team CRDs, resolves group-based team membership from `status.lastSeenGroups`, and writes `status.teams` via SSA. This change provides the input data (lastSeenGroups) and consumes the output (status.teams).

The conditional write compares `claims.Groups` against `status.lastSeenGroups` using sorted set comparison, avoiding unnecessary SSA patches when IdP group ordering changes between logins.

## Changes

| File | Change |
|------|--------|
| `internal/auth/users.go` | Add `PatchLastSeenGroups()` SSA method, `LastSeenGroups`/`Teams` fields on `UserInfo`, read both from CRD in `userFromUnstructured()` |
| `internal/api/handlers/auth_oidc.go` | Call `PatchLastSeenGroups` after EnsureSSOUser, emit audit event, add `groupsEqual` helper |
| `internal/api/handlers/users.go` | ListUsers/GetUser read `u.Teams` directly, remove `ListAllMembers` calls |
| `internal/audit/auth_events.go` | Add `RecordGroupSync` |
| `internal/auth/teams_drift_test.go` | Drift protection test consuming shared fixtures |
| `go.mod` | butler-api v0.15.0 -> v0.20.0 |

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` all pass (including 13 drift protection test cases)