### PR TITLE
feat(server): apply ClusterCreationPolicy to provider option-list handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-server
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.20.0
+	github.com/butlerdotdev/butler-api v0.21.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creack/pty v1.1.9
 	github.com/go-chi/chi/v5 v5.2.0
@@ -82,6 +82,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
-
-// Replace directive for ADR-018 implementation chain.
-replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.mod
+++ b/go.mod
@@ -82,3 +82,6 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
+
+// Replace directive for ADR-018 implementation chain.
+replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/butlerdotdev/butler-api v0.21.0 h1:zVI4doowHOHWUMVV6s+N0LcrbGasvNA5kP26Sf+kWnc=
+github.com/butlerdotdev/butler-api v0.21.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/butlerdotdev/butler-api v0.20.0 h1:dcDDiaejo5YN1a7ZZnsxJZhr/kDQk/IUcmPCYsT/PNA=
-github.com/butlerdotdev/butler-api v0.20.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/internal/api/handlers/admin_policies.go
+++ b/internal/api/handlers/admin_policies.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/butlerdotdev/butler-server/internal/k8s"
+)
+
+// AdminPoliciesHandler serves CRUD endpoints for ClusterCreationPolicy
+// resources. Platform-admin only per ADR-018 Decision section 3 (RBAC
+// scope reasoning).
+//
+// Implementation is a thin dynamic-client wrapper around the cluster's
+// ClusterCreationPolicy resources. The CRD admission webhook in
+// butler-controller validates structure on Create and Update; webhook
+// denials are unwrapped via writeWebhookError into a structured 403
+// that butler-console renders inline against the offending field.
+type AdminPoliciesHandler struct {
+	k8sClient *k8s.Client
+}
+
+// NewAdminPoliciesHandler creates an admin policies handler.
+func NewAdminPoliciesHandler(k8sClient *k8s.Client) *AdminPoliciesHandler {
+	return &AdminPoliciesHandler{k8sClient: k8sClient}
+}
+
+// PolicyListResponse wraps the list endpoint return shape.
+type PolicyListResponse struct {
+	Policies []map[string]interface{} `json:"policies"`
+	Count    int                      `json:"count"`
+}
+
+// List returns all ClusterCreationPolicy resources.
+// GET /admin/policies
+func (h *AdminPoliciesHandler) List(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	list, err := h.k8sClient.Dynamic().Resource(k8s.ClusterCreationPolicyGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to list policies: %v", err))
+		return
+	}
+	out := make([]map[string]interface{}, 0, len(list.Items))
+	for _, item := range list.Items {
+		out = append(out, item.Object)
+	}
+	writeJSON(w, http.StatusOK, PolicyListResponse{Policies: out, Count: len(out)})
+}
+
+// Get returns a single ClusterCreationPolicy by name.
+// GET /admin/policies/{name}
+func (h *AdminPoliciesHandler) Get(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	ctx := r.Context()
+	got, err := h.k8sClient.Dynamic().Resource(k8s.ClusterCreationPolicyGVR).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, fmt.Sprintf("policy %q not found", name))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to get policy: %v", err))
+		return
+	}
+	writeJSON(w, http.StatusOK, got.Object)
+}
+
+// Create creates a new ClusterCreationPolicy. The request body is the
+// full unstructured policy object; the admission webhook validates
+// structure. Webhook denials are surfaced via writeWebhookError as a
+// structured 403 the console can render inline.
+// POST /admin/policies
+func (h *AdminPoliciesHandler) Create(w http.ResponseWriter, r *http.Request) {
+	obj, err := decodePolicyBody(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Force the resource kind and apiVersion so a partial body still
+	// produces a valid CR. The console can omit these; the server
+	// stamps the canonical values.
+	obj.SetAPIVersion("butler.butlerlabs.dev/v1alpha1")
+	obj.SetKind("ClusterCreationPolicy")
+
+	ctx := r.Context()
+	created, err := h.k8sClient.Dynamic().Resource(k8s.ClusterCreationPolicyGVR).Create(ctx, obj, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			writeError(w, http.StatusConflict, fmt.Sprintf("policy %q already exists", obj.GetName()))
+			return
+		}
+		if writeWebhookError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to create policy: %v", err))
+		return
+	}
+	writeJSON(w, http.StatusCreated, created.Object)
+}
+
+// Update replaces an existing ClusterCreationPolicy. Preserves
+// metadata.resourceVersion for optimistic concurrency: the console
+// posts the resourceVersion it last fetched so a concurrent edit
+// produces a 409 rather than silently overwriting.
+// PUT /admin/policies/{name}
+func (h *AdminPoliciesHandler) Update(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	obj, err := decodePolicyBody(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if obj.GetName() != "" && obj.GetName() != name {
+		writeError(w, http.StatusBadRequest, "request body name does not match URL name")
+		return
+	}
+	obj.SetName(name)
+	obj.SetAPIVersion("butler.butlerlabs.dev/v1alpha1")
+	obj.SetKind("ClusterCreationPolicy")
+
+	ctx := r.Context()
+	updated, err := h.k8sClient.Dynamic().Resource(k8s.ClusterCreationPolicyGVR).Update(ctx, obj, metav1.UpdateOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, fmt.Sprintf("policy %q not found", name))
+			return
+		}
+		if apierrors.IsConflict(err) {
+			writeError(w, http.StatusConflict, "policy was modified by another caller; reload and retry")
+			return
+		}
+		if writeWebhookError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to update policy: %v", err))
+		return
+	}
+	writeJSON(w, http.StatusOK, updated.Object)
+}
+
+// Delete removes a ClusterCreationPolicy.
+// DELETE /admin/policies/{name}
+func (h *AdminPoliciesHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	ctx := r.Context()
+	err := h.k8sClient.Dynamic().Resource(k8s.ClusterCreationPolicyGVR).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, fmt.Sprintf("policy %q not found", name))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to delete policy: %v", err))
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// decodePolicyBody unmarshals the request body into an
+// unstructured.Unstructured. Returns a friendly error on parse
+// failure or empty body.
+func decodePolicyBody(r *http.Request) (*unstructured.Unstructured, error) {
+	var raw map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("request body is empty")
+	}
+	return &unstructured.Unstructured{Object: raw}, nil
+}

--- a/internal/api/handlers/providers.go
+++ b/internal/api/handlers/providers.go
@@ -1480,7 +1480,12 @@ func (h *ProvidersHandler) ListImages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{"images": images})
+	images, polMeta := h.applyImagePolicy(ctx, providerType, images)
+	resp := map[string]interface{}{"images": images}
+	if polMeta != nil {
+		resp["policy"] = polMeta
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // listHarvesterImages fetches VM images from Harvester.
@@ -1678,7 +1683,12 @@ func (h *ProvidersHandler) ListNetworks(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{"networks": networks})
+	networks, polMeta := h.applyNetworkPolicy(ctx, providerType, networks)
+	resp := map[string]interface{}{"networks": networks}
+	if polMeta != nil {
+		resp["policy"] = polMeta
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // listHarvesterNetworks fetches VM networks from Harvester.
@@ -2001,7 +2011,12 @@ func (h *ProvidersHandler) ListClusters(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{"clusters": clusters})
+	clusters, polMeta := h.applyClusterPolicy(ctx, "nutanix", clusters)
+	resp := map[string]interface{}{"clusters": clusters}
+	if polMeta != nil {
+		resp["policy"] = polMeta
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (h *ProvidersHandler) listNutanixClusters(ctx context.Context, endpoint string, port int32, username, password string, insecure bool, caPEM []byte) ([]ClusterInfo, error) {
@@ -2133,7 +2148,12 @@ func (h *ProvidersHandler) ListStorageContainers(w http.ResponseWriter, r *http.
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{"storageContainers": containers})
+	containers, polMeta := h.applyStorageContainerPolicy(ctx, "nutanix", containers)
+	resp := map[string]interface{}{"storageContainers": containers}
+	if polMeta != nil {
+		resp["policy"] = polMeta
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (h *ProvidersHandler) listNutanixStorageContainers(ctx context.Context, endpoint string, port int32, username, password string, insecure bool, caPEM []byte) ([]StorageContainerInfo, error) {

--- a/internal/api/handlers/providers_policy.go
+++ b/internal/api/handlers/providers_policy.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	butlerpolicy "github.com/butlerdotdev/butler-api/pkg/policy"
+
+	"github.com/butlerdotdev/butler-server/internal/api/policy"
+	"github.com/butlerdotdev/butler-server/internal/auth"
+)
+
+// GetID methods satisfy the policy.HasID interface so the generic
+// policy.Apply filter can compare option-list entries against rule
+// values without per-type code. See ADR-018 Decision section 7.
+
+// GetID returns the image's stable identifier (Nutanix UUID, Harvester
+// namespace/name).
+func (i ImageInfo) GetID() string { return i.ID }
+
+// GetID returns the network's stable identifier.
+func (n NetworkInfo) GetID() string { return n.ID }
+
+// GetID returns the cluster's stable identifier.
+func (c ClusterInfo) GetID() string { return c.ID }
+
+// GetID returns the storage container's stable identifier.
+func (s StorageContainerInfo) GetID() string { return s.ID }
+
+// resolutionContext builds the ADR-018 resolution context from the
+// request session and the resolved provider type.
+func (h *ProvidersHandler) resolutionContext(ctx context.Context, providerType string) butlerpolicy.ResolutionContext {
+	rc := butlerpolicy.ResolutionContext{ProviderType: butlerv1alpha1.ProviderType(providerType)}
+	user := auth.UserFromContext(ctx)
+	if user != nil {
+		rc.TeamName = user.SelectedTeam
+		rc.EnvironmentName = user.SelectedEnvironment
+	}
+	return rc
+}
+
+// applyImagePolicy filters and decorates an image list according to any
+// applicable ClusterCreationPolicy. Errors fetching policies are
+// non-fatal: the unfiltered list is returned so a transient List
+// failure does not block the modal entirely.
+func (h *ProvidersHandler) applyImagePolicy(ctx context.Context, providerType string, items []ImageInfo) ([]ImageInfo, *policy.Metadata) {
+	rc := h.resolutionContext(ctx, providerType)
+	filtered, meta, err := policy.Apply(ctx, h.k8sClient.Dynamic(), items, butlerv1alpha1.OptionTypeImage, rc, nil)
+	if err != nil {
+		return items, nil
+	}
+	return filtered, meta
+}
+
+// applyNetworkPolicy filters and decorates a network list.
+func (h *ProvidersHandler) applyNetworkPolicy(ctx context.Context, providerType string, items []NetworkInfo) ([]NetworkInfo, *policy.Metadata) {
+	rc := h.resolutionContext(ctx, providerType)
+	filtered, meta, err := policy.Apply(ctx, h.k8sClient.Dynamic(), items, butlerv1alpha1.OptionTypeNetwork, rc, nil)
+	if err != nil {
+		return items, nil
+	}
+	return filtered, meta
+}
+
+// applyClusterPolicy filters and decorates a Nutanix cluster list.
+func (h *ProvidersHandler) applyClusterPolicy(ctx context.Context, providerType string, items []ClusterInfo) ([]ClusterInfo, *policy.Metadata) {
+	rc := h.resolutionContext(ctx, providerType)
+	filtered, meta, err := policy.Apply(ctx, h.k8sClient.Dynamic(), items, butlerv1alpha1.OptionTypeCluster, rc, nil)
+	if err != nil {
+		return items, nil
+	}
+	return filtered, meta
+}
+
+// applyStorageContainerPolicy filters and decorates a Nutanix storage
+// container list.
+func (h *ProvidersHandler) applyStorageContainerPolicy(ctx context.Context, providerType string, items []StorageContainerInfo) ([]StorageContainerInfo, *policy.Metadata) {
+	rc := h.resolutionContext(ctx, providerType)
+	filtered, meta, err := policy.Apply(ctx, h.k8sClient.Dynamic(), items, butlerv1alpha1.OptionTypeStorageContainer, rc, nil)
+	if err != nil {
+		return items, nil
+	}
+	return filtered, meta
+}

--- a/internal/api/policy/apply.go
+++ b/internal/api/policy/apply.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package policy applies ADR-018 ClusterCreationPolicy curation to
+// butler-server's option-list responses. Resolution itself lives in
+// butler-api/pkg/policy; this package wraps it with the response-shape
+// transformation specific to the four list handlers.
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	policypkg "github.com/butlerdotdev/butler-api/pkg/policy"
+)
+
+// Metadata is the optional `policy` block included in option-list
+// responses when a rule applies. butler-console reads this and renders
+// the corresponding affordances (badge, pre-select, "curated by policy"
+// label). See ADR-018 Decision section 7.
+type Metadata struct {
+	Name              string   `json:"name"`
+	Mode              string   `json:"mode"`
+	Values            []string `json:"values,omitempty"`
+	Default           string   `json:"default,omitempty"`
+	RecommendedReason string   `json:"recommendedReason,omitempty"`
+}
+
+// HasID is implemented by the per-option-type response entry types
+// (ImageInfo, NetworkInfo, ClusterInfo, StorageContainerInfo) so the
+// policy filter can compare against rule values without per-type code.
+type HasID interface {
+	GetID() string
+}
+
+// listGVR is the GVR for ClusterCreationPolicy. Kept local to avoid an
+// import cycle with the k8s package.
+var listGVR = schema.GroupVersionResource{
+	Group:    "butler.butlerlabs.dev",
+	Version:  "v1alpha1",
+	Resource: "clustercreationpolicies",
+}
+
+// ListPolicies fetches all ClusterCreationPolicy resources from the
+// cluster. Uses the dynamic client; converts unstructured items into
+// typed instances for the resolver.
+func ListPolicies(ctx context.Context, dyn dynamic.Interface) ([]butlerv1alpha1.ClusterCreationPolicy, error) {
+	ul, err := dyn.Resource(listGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list ClusterCreationPolicy: %w", err)
+	}
+	out := make([]butlerv1alpha1.ClusterCreationPolicy, 0, len(ul.Items))
+	for i := range ul.Items {
+		raw, err := json.Marshal(ul.Items[i].Object)
+		if err != nil {
+			return nil, fmt.Errorf("marshal ClusterCreationPolicy %q: %w", ul.Items[i].GetName(), err)
+		}
+		var p butlerv1alpha1.ClusterCreationPolicy
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("unmarshal ClusterCreationPolicy %q: %w", ul.Items[i].GetName(), err)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// Apply runs policy resolution for the given context and option type,
+// then filters or reorders the entry slice and returns the filtered
+// slice plus optional response metadata.
+//
+// For pin and allowList modes the entries are filtered to those whose
+// ID matches a rule Value. For recommended mode the entries are
+// reordered to put recommended IDs first, and metadata is populated so
+// the console can badge them. For default mode no filtering happens and
+// metadata names the pre-selected ID. When no rule applies, the entries
+// pass through unchanged and metadata is nil.
+func Apply[T HasID](ctx context.Context, dyn dynamic.Interface, items []T, optType butlerv1alpha1.OptionType, resCtx policypkg.ResolutionContext, policyName *string) ([]T, *Metadata, error) {
+	policies, err := ListPolicies(ctx, dyn)
+	if err != nil {
+		return items, nil, err
+	}
+	if len(policies) == 0 {
+		return items, nil, nil
+	}
+	rules, sources := policypkg.ResolveWithSources(resCtx, policies)
+	rule, ok := rules[optType]
+	if !ok {
+		return items, nil, nil
+	}
+	name := sources[optType]
+	if policyName != nil {
+		*policyName = name
+	}
+
+	meta := &Metadata{
+		Name:              name,
+		Mode:              string(rule.Mode),
+		Values:            rule.Values,
+		Default:           rule.Default,
+		RecommendedReason: rule.RecommendedReason,
+	}
+
+	switch rule.Mode {
+	case butlerv1alpha1.OptionModePin, butlerv1alpha1.OptionModeAllowList:
+		filtered := make([]T, 0, len(items))
+		allow := map[string]struct{}{}
+		for _, v := range rule.Values {
+			allow[v] = struct{}{}
+		}
+		for _, item := range items {
+			if _, in := allow[item.GetID()]; in {
+				filtered = append(filtered, item)
+			}
+		}
+		return filtered, meta, nil
+	case butlerv1alpha1.OptionModeRecommended:
+		recommended := map[string]struct{}{}
+		for _, v := range rule.Values {
+			recommended[v] = struct{}{}
+		}
+		head := make([]T, 0, len(rule.Values))
+		tail := make([]T, 0, len(items))
+		for _, item := range items {
+			if _, in := recommended[item.GetID()]; in {
+				head = append(head, item)
+			} else {
+				tail = append(tail, item)
+			}
+		}
+		return append(head, tail...), meta, nil
+	case butlerv1alpha1.OptionModeDefault:
+		return items, meta, nil
+	default:
+		return items, nil, nil
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -226,6 +226,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 	certificateHandler := handlers.NewCertificateHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "certificates"))
 	gitopsHandler := handlers.NewGitOpsHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "gitops"))
 	identityProviderHandler := handlers.NewIdentityProvidersHandler(cfg.K8sClient, cfg.Config)
+	adminPoliciesHandler := handlers.NewAdminPoliciesHandler(cfg.K8sClient)
 	networksHandler := handlers.NewNetworksHandler(cfg.K8sClient, cfg.Config)
 	workspaceHandler := handlers.NewWorkspaceHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "workspaces"))
 	observabilityHandler := handlers.NewObservabilityHandler(cfg.K8sClient, cfg.Config, cfg.Logger.With("component", "observability"))
@@ -482,6 +483,10 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 				r.Get("/identity-providers", identityProviderHandler.List)
 				r.Get("/identity-providers/{name}", identityProviderHandler.Get)
 
+				// ClusterCreationPolicy (read-only for viewers, ADR-018)
+				r.Get("/policies", adminPoliciesHandler.List)
+				r.Get("/policies/{name}", adminPoliciesHandler.Get)
+
 				// Network pools (read-only for viewers)
 				r.Get("/networks", networksHandler.ListNetworkPools)
 				r.Get("/networks/{namespace}/{name}", networksHandler.GetNetworkPool)
@@ -518,6 +523,11 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 					r.Put("/identity-providers/{name}", identityProviderHandler.Update)
 					r.Delete("/identity-providers/{name}", identityProviderHandler.Delete)
 					r.Post("/identity-providers/{name}/validate", identityProviderHandler.Validate)
+
+					// ClusterCreationPolicy mutations (admin only, ADR-018)
+					r.Post("/policies", adminPoliciesHandler.Create)
+					r.Put("/policies/{name}", adminPoliciesHandler.Update)
+					r.Delete("/policies/{name}", adminPoliciesHandler.Delete)
 
 					// Addon catalog management (admin only)
 					r.Post("/addons/catalog", addonsHandler.CreateAddonDefinition)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -97,6 +97,12 @@ var (
 		Resource: "loadbalancerrequests",
 	}
 
+	ClusterCreationPolicyGVR = schema.GroupVersionResource{
+		Group:    "butler.butlerlabs.dev",
+		Version:  "v1alpha1",
+		Resource: "clustercreationpolicies",
+	}
+
 	TenantControlPlaneGVR = schema.GroupVersionResource{
 		Group:    "steward.butlerlabs.dev",
 		Version:  "v1alpha1",


### PR DESCRIPTION
Fourth PR in the five-repo ADR-018 implementation chain.

## What this adds

### Modal-time policy filtering

- `internal/api/policy/` package wrapping `butler-api/pkg/policy.Resolve` with the response-shape transformation: filter for pin/allowList, reorder for recommended, pass-through for default.
- `internal/api/handlers/providers_policy.go` with `GetID` methods on the four response types plus `applyXxxPolicy` helpers per option type.
- Four list handler updates in `internal/api/handlers/providers.go`. Each now appends an optional `policy` block to the response envelope.
- `ClusterCreationPolicyGVR` added to `internal/k8s/client.go`.

### Admin authoring endpoints (added in commit 326c539 per ADR-018 amendment butlerdotdev/butler-controller#106)

Five new endpoints under `/admin/policies` enabling UI authoring:

- `GET /admin/policies` (platform-viewer + above)
- `GET /admin/policies/{name}` (platform-viewer + above)
- `POST /admin/policies` (platform-admin only)
- `PUT /admin/policies/{name}` (platform-admin only; preserves resourceVersion for optimistic concurrency)
- `DELETE /admin/policies/{name}` (platform-admin only)

Webhook denials are unwrapped via the existing `writeWebhookError` helper into a structured 403 the console renders inline against the offending field (ADR-010).

## Depends on

- butlerdotdev/butler-api#45 (types + `pkg/policy` resolver, sourced via local replace)

## Replace directives in flight

`go.mod` carries `replace github.com/butlerdotdev/butler-api => ../butler-api`. Removed at merge phase.

## Backward compatibility

Existing API consumers ignore the optional `policy` block on the four list responses. New admin endpoints have no existing consumers.

## Implementation chain status

- [x] PR 1: butler-api types + pkg/policy resolver (butlerdotdev/butler-api#45)
- [x] PR 2: butler-charts CRD sync (butlerdotdev/butler-charts#128)
- [x] PR 3: butler-controller webhooks (butlerdotdev/butler-controller#105)
- [x] PR 4: butler-server modal filtering + admin endpoints (this PR)
- [x] PR 5: butler-console modal + admin pages (butlerdotdev/butler-console#76)

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/api/...` passes