### PR TITLE
feat(auth): issue butler-session JWT from cli device flow

### DIFF
--- a/cmd/devsign/README.md
+++ b/cmd/devsign/README.md
@@ -1,0 +1,61 @@
+# devsign
+
+Dev-time helper that mints butler-server session JWTs for end-to-end testing
+of the CLI device flow. Located in `cmd/devsign/` and built like any other
+`cmd/` binary.
+
+## What it is
+
+A small CLI that signs a `UserSession` JWT using the same HS256 algorithm and
+secret that butler-server's `SessionService` uses. The output is a valid
+butler-server session token — `SessionMiddleware` accepts it as if it came
+from a normal login.
+
+## When to use it
+
+For local E2E verification of changes that touch the CLI device-flow contract
+(originally the `feat(auth): issue butler-session JWT from cli device flow`
+change). The `POST /api/auth/cli/approve` step requires an authenticated
+session; in a local dev server with no IdP wired up, devsign produces that
+session out-of-band so you can drive the approval without a browser or a real
+OIDC flow.
+
+## Usage
+
+```bash
+CGO_ENABLED=0 go build -o /tmp/devsign ./cmd/devsign
+
+# Mint an admin session JWT (24h default lifetime)
+/tmp/devsign \
+  -secret "$BUTLER_JWT_SECRET" \
+  -email tester@example.com \
+  -name "Tester" \
+  -platform-admin
+
+# Custom expiry
+/tmp/devsign -secret ... -email ... -expiry 1h
+```
+
+Flags:
+
+| Flag | Purpose |
+|---|---|
+| `-secret` | JWT signing secret. Must match `BUTLER_JWT_SECRET` of the running butler-server. Defaults to the env var of the same name. |
+| `-email` | Email to embed in the session (required). |
+| `-name` | Optional display name. |
+| `-platform-admin` | Set `IsPlatformAdmin: true` on the session. |
+| `-expiry` | Session lifetime (default 24h). |
+
+The JWT is printed to stdout. Errors go to stderr with a non-zero exit.
+
+## Not for production
+
+This tool sidesteps every identity check (no IdP, no User CRD, no Team CRD
+resolution) and trusts the caller to supply identity claims directly. The risk
+model is plain: anyone with the running butler-server's `BUTLER_JWT_SECRET`
+can mint a platform-admin session JWT with this tool. That secret is the only
+gate.
+
+Do not build, ship, or deploy devsign anywhere a production butler-server can
+be reached. Treat `BUTLER_JWT_SECRET` accordingly: it is a session-issuance
+secret, not a config knob.

--- a/cmd/devsign/main.go
+++ b/cmd/devsign/main.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package main is the entry point for devsign — a small helper that mints
+// butler-server session JWTs for end-to-end testing of the CLI device flow.
+//
+// This is dev-time test infrastructure. The signing secret must match the
+// BUTLER_JWT_SECRET that a running butler-server instance is configured with,
+// so the only realistic use is local dev mode against a butler-server you
+// started yourself. Do not deploy.
+//
+// Usage:
+//
+//	devsign -email alice@example.com -platform-admin -secret $BUTLER_JWT_SECRET
+//
+// Prints the JWT to stdout on success. Exits non-zero on missing flags or
+// signing errors with a message on stderr.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/butlerdotdev/butler-server/internal/auth"
+)
+
+func main() {
+	var (
+		secret        string
+		email         string
+		name          string
+		platformAdmin bool
+		expiry        time.Duration
+	)
+
+	flag.StringVar(&secret, "secret", os.Getenv("BUTLER_JWT_SECRET"), "JWT signing secret (defaults to BUTLER_JWT_SECRET env)")
+	flag.StringVar(&email, "email", "", "user email to embed in the session")
+	flag.StringVar(&name, "name", "", "user display name (optional)")
+	flag.BoolVar(&platformAdmin, "platform-admin", false, "set IsPlatformAdmin on the session")
+	flag.DurationVar(&expiry, "expiry", 24*time.Hour, "session JWT lifetime")
+	flag.Parse()
+
+	if secret == "" {
+		fmt.Fprintln(os.Stderr, "devsign: -secret is required (or set BUTLER_JWT_SECRET)")
+		os.Exit(2)
+	}
+	if email == "" {
+		fmt.Fprintln(os.Stderr, "devsign: -email is required")
+		os.Exit(2)
+	}
+
+	svc := auth.NewSessionService(secret, expiry)
+	user := &auth.UserSession{
+		Subject:         "devsign:" + email,
+		Email:           email,
+		Name:            name,
+		IsPlatformAdmin: platformAdmin,
+	}
+
+	token, err := svc.CreateSession(user)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "devsign: create session: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(token)
+}

--- a/internal/api/handlers/auth_device.go
+++ b/internal/api/handlers/auth_device.go
@@ -306,10 +306,20 @@ func (h *DeviceFlowHandler) DeviceRefresh(w http.ResponseWriter, r *http.Request
 }
 
 // cliTokenResponse is the shape returned by both the token and refresh endpoints.
+//
+// The kubeconfig embeds a Kubernetes ServiceAccount token used to talk to the
+// K8s API directly (ADR-002). SessionToken is a butler-server session JWT used
+// when the CLI calls protected butler-server HTTP endpoints (cert rotation,
+// GitOps lifecycle, provider image/network discovery, etc.) that go through
+// SessionMiddleware. The two tokens authenticate the same identity to
+// different APIs; they expire independently. ADR-016 amendment for the
+// rationale.
 type cliTokenResponse struct {
 	User              cliUserResponse `json:"user"`
 	Kubeconfig        string          `json:"kubeconfig"`
 	ExpiresAt         string          `json:"expires_at"`
+	SessionToken      string          `json:"session_token"`
+	SessionExpiresAt  string          `json:"session_expires_at"`
 	RefreshToken      string          `json:"refresh_token"`
 	RefreshExpiresAt  string          `json:"refresh_expires_at"`
 }
@@ -349,6 +359,18 @@ func (h *DeviceFlowHandler) provisionCLIAccess(r *http.Request, session *auth.Us
 		return nil, fmt.Errorf("build kubeconfig: %w", err)
 	}
 
+	// Issue a butler-server session JWT for protected HTTP endpoints
+	// (SessionMiddleware-gated routes the CLI calls beyond the K8s API).
+	// CreateSession canonicalizes session.Email; subsequent reads in this
+	// function get the canonical form. The SA above was provisioned with
+	// the same (already-canonical) email coming from upstream identity
+	// flows (DeviceApprove or refresh-token lookup).
+	sessionToken, err := h.sessionService.CreateSession(session)
+	if err != nil {
+		return nil, fmt.Errorf("create session token: %w", err)
+	}
+	sessionExpiresAt := time.Now().Add(h.sessionService.Expiry())
+
 	// Generate refresh token
 	refreshToken, err := auth.GenerateRefreshToken()
 	if err != nil {
@@ -367,6 +389,8 @@ func (h *DeviceFlowHandler) provisionCLIAccess(r *http.Request, session *auth.Us
 		},
 		Kubeconfig:       base64.StdEncoding.EncodeToString(kubeconfigBytes),
 		ExpiresAt:        expiresAt.Format(time.RFC3339),
+		SessionToken:     sessionToken,
+		SessionExpiresAt: sessionExpiresAt.Format(time.RFC3339),
 		RefreshToken:     refreshToken,
 		RefreshExpiresAt: refreshExpiresAt.Format(time.RFC3339),
 	}, nil

--- a/internal/api/handlers/auth_device_test.go
+++ b/internal/api/handlers/auth_device_test.go
@@ -114,6 +114,58 @@ func TestDeviceAuthorize_IgnoresForwardedHeadersWithoutTrust(t *testing.T) {
 	}
 }
 
+// TestCLITokenResponse_IncludesSessionTokenFields locks in the contract
+// surface the CLI consumes: the device-flow token response carries a
+// session_token (butler-server JWT for protected HTTP endpoints) and
+// session_expires_at alongside the existing kubeconfig + SA token expiry.
+// The provisionCLIAccess wiring is not unit-tested directly because it
+// depends on a real K8s client to mint SA tokens; that path is exercised
+// by the manual curl + K8s integration check documented in the commit
+// notes. This test guards the JSON shape so the CLI side and the server
+// side cannot silently drift.
+func TestCLITokenResponse_IncludesSessionTokenFields(t *testing.T) {
+	resp := cliTokenResponse{
+		User: cliUserResponse{
+			Email: "alice@example.com",
+			Name:  "Alice",
+		},
+		Kubeconfig:       "base64-kubeconfig",
+		ExpiresAt:        "2026-05-29T00:00:00Z",
+		SessionToken:     "eyJhbGc.test.signature",
+		SessionExpiresAt: "2026-05-29T00:00:00Z",
+		RefreshToken:     "refresh-token-value",
+		RefreshExpiresAt: "2026-06-27T00:00:00Z",
+	}
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	requiredKeys := []string{
+		"user", "kubeconfig", "expires_at",
+		"session_token", "session_expires_at",
+		"refresh_token", "refresh_expires_at",
+	}
+	for _, k := range requiredKeys {
+		if _, ok := decoded[k]; !ok {
+			t.Errorf("response missing required key %q (body=%s)", k, string(body))
+		}
+	}
+
+	if got := decoded["session_token"]; got != "eyJhbGc.test.signature" {
+		t.Errorf("session_token = %v, want round-trip of input", got)
+	}
+	if got := decoded["session_expires_at"]; got != "2026-05-29T00:00:00Z" {
+		t.Errorf("session_expires_at = %v, want round-trip of input", got)
+	}
+}
+
 // TestDeviceAuthorize_ErrorsWhenNoPublicURLDerivable closes the last
 // coverage gap: with config at defaults and an empty Host on the
 // request, the helper returns an empty string and the handler must

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -118,6 +118,13 @@ func NewSessionService(secret string, expiry time.Duration) *SessionService {
 	}
 }
 
+// Expiry returns the session JWT lifetime configured at construction time.
+// Used by the CLI device flow handler to compute an absolute expiry to return
+// to the client alongside the freshly issued session JWT.
+func (s *SessionService) Expiry() time.Duration {
+	return s.expiry
+}
+
 // CreateSession creates a new session token for a user.
 func (s *SessionService) CreateSession(user *UserSession) (string, error) {
 	now := time.Now()

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSessionService_Expiry confirms the accessor returns the duration the
+// service was constructed with. The CLI device flow handler relies on this
+// to compute an absolute session-token expiry to return alongside the JWT.
+func TestSessionService_Expiry(t *testing.T) {
+	tests := []struct {
+		name   string
+		expiry time.Duration
+	}{
+		{"default 24h", 24 * time.Hour},
+		{"short 5m", 5 * time.Minute},
+		{"long 7d", 7 * 24 * time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSessionService("test-secret", tt.expiry)
+			if got := s.Expiry(); got != tt.expiry {
+				t.Errorf("Expiry() = %v, want %v", got, tt.expiry)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this changes

The CLI device flow now returns a butler-server session JWT (`session_token` plus `session_expires_at`) alongside the existing kubeconfig. Previously the flow returned only a Kubernetes ServiceAccount token embedded in the kubeconfig, which authenticated direct K8s API calls but did not validate against butler-server's protected HTTP endpoints. The new field lets the CLI talk to butler-server's protected endpoints (cert rotation, GitOps lifecycle, ProviderConfig discovery, IdP create) using the same identity device-flow login already establishes.

Three commits: the feature change (`8726627`), a small dev-mode JWT signer at `cmd/devsign/` for local E2E testing (`f10ece6`), and a README adjacent to that tool (`21299dd`).

## Why

ADR-016 established device-flow login that returned a scoped kubeconfig, which works for the CRD-as-API path on the K8s API server. The CLI gap audit (`butler-cli/.secrets/cli-console-gap-2026-05.md`, Section 7) identified a category of operations that live only on butler-server's HTTP surface and have no CRD equivalent (the cert service, GitOps orchestration, ProviderConfig image and network discovery). The CLI had no way to authenticate to those. This change is the foundation that unblocks them. See the ADR-016 amendment dated 2026-05-28 (in the companion PR on butler-cli) for the wire contract and the rationale on keeping the two expiries in sync.

## Verification

`CGO_ENABLED=0 go vet ./...` clean. `go build ./cmd/server` and `go build ./cmd/devsign` both build. `go test ./internal/auth/... ./internal/api/handlers/...` and the full `go test ./...` pass including two new tests: `TestSessionService_Expiry` and `TestCLITokenResponse_IncludesSessionTokenFields`. The latter locks the JSON shape of the token response so the CLI side and the server side cannot silently drift.

Live against butler-beta on 2026-05-28: ran the binary locally with `BUTLER_JWT_SECRET=e2e-test-only-not-production-do-not-deploy` and butler-beta kubeconfig, drove the full device flow via curl (`POST /api/auth/cli/device` then `POST /api/auth/cli/verify` then mint admin JWT via devsign then `POST /api/auth/cli/approve` then `POST /api/auth/cli/token`). The token response carried all seven fields including `session_token` (445 chars HS256) and `session_expires_at` (RFC3339, 24h from issuance). `GET /api/auth/me` with the session_token as Bearer returned 200 with the expected `{email, name, teams, isPlatformAdmin}`. Tampering the last three characters of the JWT and re-issuing the same call returned 401 with the documented `{"error":"invalid session"}` envelope. The one ServiceAccount and one ClusterRoleBinding created on butler-beta by the test login were deleted after.

Not unit-tested directly: the `provisionCLIAccess` wiring that calls `CreateSession` and populates the new fields. `CLIServiceAccountManager` is a concrete type, not an interface; faking it for a handler-level unit test would require an interface extraction wider than this change. The JSON contract is locked by `TestCLITokenResponse_IncludesSessionTokenFields` and the plumbing was exercised live above.

## Dependencies / merge order

None upstream. This PR is the foundation for the rest of Stage 2 P1. PR #5 (`butler-cli: feat/cluster-certs-rotate`) specifically requires this to be merged first so butler-server's device flow issues a session_token the CLI can use.

## Not in scope

- The ADR-016 amendment text. That is in the companion butler-cli PR `docs/adr-016-cli-session-jwt`.
- An interface extraction on `CLIServiceAccountManager` to make the handler unit-testable end-to-end without K8s.
- The cert service partial-success bug surfaced during live testing of PR #5. That is its own finding in `butler-server/.secrets/notes.md` and gets its own future change.
- Documentation in the production butler-server docs beyond the package doc comment on `cliTokenResponse` and the inline rationale in `provisionCLIAccess`. The user-facing reference is the ADR amendment.
