### PR TITLE
feat(server): add DELETE /api/gitops/config endpoint

### DIFF
--- a/internal/api/handlers/gitops.go
+++ b/internal/api/handlers/gitops.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -33,8 +34,60 @@ import (
 	"github.com/butlerdotdev/butler-server/internal/gitops"
 	"github.com/butlerdotdev/butler-server/internal/k8s"
 	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+// Git provider configuration is stored as a ConfigMap plus a credential Secret
+// in the system namespace. These names mirror what SaveConfig writes.
+const (
+	gitOpsConfigMapName = "butler-gitops-config"
+	gitOpsSecretName    = "butler-gitops-credentials"
+)
+
+// gitConfigDeleter is the minimal slice of the k8s client that ClearConfig
+// needs. Defined as an interface so the clear logic can be unit-tested with a
+// fake; the concrete *k8s.Client satisfies it. butler-server's k8s client is
+// not fake-injectable (it holds a concrete *kubernetes.Clientset), so the
+// testable seam is this interface rather than a fake clientset.
+type gitConfigDeleter interface {
+	DeleteConfigMap(ctx context.Context, namespace, name string) error
+	DeleteSecret(ctx context.Context, namespace, name string) error
+}
+
+// clearGitProviderConfig deletes the GitOps ConfigMap and credential Secret.
+// It reports whether anything was actually deleted (false means both were
+// already absent). A NotFound on either resource is treated as "already gone",
+// not an error, so the operation is idempotent at the storage layer.
+//
+// Both deletes are attempted regardless of an intermediate error (best-effort
+// cleanup): a failure deleting the ConfigMap must not strand the credential
+// Secret. Non-NotFound errors are aggregated and returned together. The
+// ConfigMap is deleted first so that a partial failure leaves an inert orphan
+// rather than a ConfigMap pointing at a deleted Secret (which would make
+// GetConfig falsely report a working configuration).
+func clearGitProviderConfig(ctx context.Context, d gitConfigDeleter, namespace string) (bool, error) {
+	deleted := false
+	var errs []error
+
+	if err := d.DeleteConfigMap(ctx, namespace, gitOpsConfigMapName); err != nil {
+		if !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting configmap %s: %w", gitOpsConfigMapName, err))
+		}
+	} else {
+		deleted = true
+	}
+
+	if err := d.DeleteSecret(ctx, namespace, gitOpsSecretName); err != nil {
+		if !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting secret %s: %w", gitOpsSecretName, err))
+		}
+	} else {
+		deleted = true
+	}
+
+	return deleted, errors.Join(errs...)
+}
 
 // GitOpsHandler handles GitOps-related API requests.
 type GitOpsHandler struct {
@@ -180,6 +233,32 @@ func (h *GitOpsHandler) SaveConfig(w http.ResponseWriter, r *http.Request) {
 		Organization: req.Organization,
 		Username:     validation.Username,
 	})
+}
+
+// ClearConfig removes the platform Git provider configuration by deleting the
+// GitOps ConfigMap and credential Secret. Returns 204 when something was
+// deleted, 404 when nothing was configured, and 500 on a Kubernetes API error.
+func (h *GitOpsHandler) ClearConfig(w http.ResponseWriter, r *http.Request) {
+	clearConfigResponse(w, r.Context(), h.k8sClient, h.config.SystemNamespace, h.logger)
+}
+
+// clearConfigResponse runs the clear and writes the HTTP response. Split from
+// the handler method so the status mapping (204/404/500) is unit-testable with
+// a fake gitConfigDeleter, without a fake Kubernetes clientset.
+func clearConfigResponse(w http.ResponseWriter, ctx context.Context, d gitConfigDeleter, namespace string, logger *slog.Logger) {
+	deleted, err := clearGitProviderConfig(ctx, d, namespace)
+	if err != nil {
+		logger.Error("Failed to clear Git provider config", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to clear Git provider configuration")
+		return
+	}
+	if !deleted {
+		writeError(w, http.StatusNotFound, "no Git provider configured")
+		return
+	}
+
+	logger.Info("Git provider configuration cleared")
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // ListRepositories lists repositories from the configured provider.

--- a/internal/api/handlers/gitops_clear_test.go
+++ b/internal/api/handlers/gitops_clear_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// fakeGitConfigDeleter records calls and returns canned errors, standing in
+// for *k8s.Client (which is not fake-injectable). It implements
+// gitConfigDeleter.
+type fakeGitConfigDeleter struct {
+	configMapErr error
+	secretErr    error
+	cmCalled     bool
+	secretCalled bool
+}
+
+func (f *fakeGitConfigDeleter) DeleteConfigMap(_ context.Context, _, _ string) error {
+	f.cmCalled = true
+	return f.configMapErr
+}
+
+func (f *fakeGitConfigDeleter) DeleteSecret(_ context.Context, _, _ string) error {
+	f.secretCalled = true
+	return f.secretErr
+}
+
+func notFound(resource, name string) error {
+	return apierrors.NewNotFound(schema.GroupResource{Resource: resource}, name)
+}
+
+func TestClearGitProviderConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmErr       error
+		secretErr   error
+		wantDeleted bool
+		wantErr     bool
+	}{
+		{name: "both present -> deleted", wantDeleted: true},
+		{
+			name:        "both missing -> nothing deleted, no error (idempotent)",
+			cmErr:       notFound("configmaps", gitOpsConfigMapName),
+			secretErr:   notFound("secrets", gitOpsSecretName),
+			wantDeleted: false,
+		},
+		{
+			name:        "configmap missing, secret present -> deleted",
+			cmErr:       notFound("configmaps", gitOpsConfigMapName),
+			wantDeleted: true,
+		},
+		{
+			name:        "configmap real error -> error, but secret delete still attempted",
+			cmErr:       errors.New("apiserver unreachable"),
+			wantDeleted: true, // secret delete succeeds (best-effort)
+			wantErr:     true,
+		},
+		{
+			name:      "secret real error -> error propagated",
+			secretErr: errors.New("forbidden"),
+			wantErr:   true,
+		},
+		{
+			name:      "both real errors -> aggregated, nothing deleted",
+			cmErr:     errors.New("apiserver unreachable"),
+			secretErr: errors.New("forbidden"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &fakeGitConfigDeleter{configMapErr: tt.cmErr, secretErr: tt.secretErr}
+			deleted, err := clearGitProviderConfig(context.Background(), d, "butler-system")
+
+			// Best-effort: both deletes are always attempted, even when the
+			// first fails. This is the P1.2 guarantee (a ConfigMap failure
+			// must not strand the credential Secret).
+			if !d.cmCalled {
+				t.Errorf("DeleteConfigMap was not called")
+			}
+			if !d.secretCalled {
+				t.Errorf("DeleteSecret was not called (best-effort cleanup requires attempting both)")
+			}
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if deleted != tt.wantDeleted {
+				t.Fatalf("deleted = %v, want %v", deleted, tt.wantDeleted)
+			}
+		})
+	}
+}
+
+// TestClearConfigResponse covers the HTTP status mapping (204/404/500) via the
+// fake deleter, without a fake Kubernetes clientset.
+func TestClearConfigResponse(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tests := []struct {
+		name       string
+		cmErr      error
+		secretErr  error
+		wantStatus int
+	}{
+		{name: "deleted -> 204", wantStatus: 204},
+		{
+			name:       "nothing configured -> 404",
+			cmErr:      notFound("configmaps", gitOpsConfigMapName),
+			secretErr:  notFound("secrets", gitOpsSecretName),
+			wantStatus: 404,
+		},
+		{
+			name:       "k8s error -> 500",
+			cmErr:      errors.New("apiserver unreachable"),
+			secretErr:  errors.New("apiserver unreachable"),
+			wantStatus: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &fakeGitConfigDeleter{configMapErr: tt.cmErr, secretErr: tt.secretErr}
+			rec := httptest.NewRecorder()
+			clearConfigResponse(rec, context.Background(), d, "butler-system", logger)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -381,6 +381,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 				r.Group(func(r chi.Router) {
 					r.Use(adminMiddleware)
 					r.Post("/config", gitopsHandler.SaveConfig)
+					r.Delete("/config", gitopsHandler.ClearConfig)
 					r.Post("/preview", gitopsHandler.PreviewManifest)
 				})
 			})


### PR DESCRIPTION
## What

Adds `DELETE /api/gitops/config`, backed by `GitOpsHandler.ClearConfig`. It removes the platform Git provider configuration by deleting the `butler-gitops-config` ConfigMap and the `butler-gitops-credentials` Secret in the system namespace (the resources `SaveConfig` writes).

## Why

- **The console's "clear Git provider" flow is broken today.** `butler-console`'s `gitopsApi.clearConfig()` calls `DELETE /gitops/config`, but the router only registered GET and POST, so that call returns 404/405. This adds the missing route.
- **butler-cli Feature 2.1** (`butleradm gitops config clear`) depends on this endpoint. The CLI is server-orchestrated for GitOps operations and cannot delete the Secret/ConfigMap directly under its credential-only auth model.

## Behavior

- `204 No Content` when the ConfigMap and/or Secret were deleted.
- `404 Not Found` (`{"error":"no Git provider configured"}`) when neither existed. Uses the established not-found pattern and is not a server error; clients treat it as "already cleared".
- `500` with the standard error envelope on a Kubernetes API failure (detailed error logged server-side; response body sanitized, no resource-name leakage).
- Idempotent at the storage layer: NotFound on an individual resource is "already gone", not an error.
- Best-effort cleanup: both deletes are attempted even if one fails, so a ConfigMap-delete failure cannot strand the credential Secret. Non-NotFound errors are aggregated. The ConfigMap is deleted first so a partial failure leaves an inert orphan rather than a ConfigMap pointing at a deleted Secret.

## RBAC

Route registered inside the existing admin-gated group alongside `POST /config`, so clearing requires the same admin role (`RequireAdmin`) as saving. The server ServiceAccount already has K8s delete on secrets (cluster ClusterRole) and on configmaps (the namespaced `gitops-config` Role in the system namespace), so no chart change is needed.

## Tests

- `clearGitProviderConfig` (deleter-interface seam; `*k8s.Client` is not fake-injectable, so the seam is a narrow interface it satisfies): both-present, both-missing (idempotent), one-present, configmap-error-still-attempts-secret, secret-error, both-error-aggregated.
- `clearConfigResponse`: HTTP status mapping 204 / 404 / 500.
- `go vet` clean, server builds.

## Rollback

Reverting this PR removes the route. Impact: butler-cli `gitops config clear` would fail, and the console's `clearConfig()` returns to its current 404. Production is unaffected because no caller depends on the endpoint succeeding today (the console button is already broken; the CLI command is not yet released).

## Out of scope

butler-server has no fake-K8s-client handler-test pattern (`k8s.Client` holds a concrete `*kubernetes.Clientset`). This PR uses a local `gitConfigDeleter` interface seam rather than refactoring the shared client. A cluster-wide refactor of `k8s.Client` to `kubernetes.Interface` for testable fakes across all handlers is tracked as separate followup work.