### PR TITLE
fix(gitops): require Flux controllers present, not just the namespace

### DIFF
--- a/internal/gitops/provider_flux.go
+++ b/internal/gitops/provider_flux.go
@@ -186,20 +186,42 @@ func (p *FluxProvider) GenerateBootstrapStructure(cfg BootstrapConfig) (map[stri
 	return files, nil
 }
 
+// fluxControllerNames are the gotk controller Deployments a Flux install
+// creates in flux-system. Their presence is the positive signal that Flux is
+// actually installed; the namespace existing on its own is not (a prior
+// bootstrap or uninstall can leave an empty flux-system namespace behind).
+var fluxControllerNames = map[string]bool{
+	"source-controller":       true,
+	"kustomize-controller":    true,
+	"helm-controller":         true,
+	"notification-controller": true,
+}
+
 // CheckInstalled verifies Flux is installed on the cluster.
 func (p *FluxProvider) CheckInstalled(ctx context.Context, kubeconfig []byte) (*ProviderStatus, error) {
 	clientset, err := createClientset(kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clientset: %w", err)
 	}
+	return detectFluxStatus(ctx, clientset)
+}
 
+// detectFluxStatus reports whether Flux is installed and ready in flux-system.
+// It takes a kubernetes.Interface so the detection is unit-testable with a fake
+// clientset.
+//
+// Installed requires at least one recognized Flux controller Deployment to be
+// present: an existing flux-system namespace alone is not proof of an install,
+// and treating it as such reported an empty leftover namespace as healthy.
+// Installed and Ready stay distinct so an installed-but-not-all-ready Flux is
+// Installed=true, Ready=false rather than reported as absent.
+func detectFluxStatus(ctx context.Context, clientset kubernetes.Interface) (*ProviderStatus, error) {
 	status := &ProviderStatus{
 		Installed: false,
 		Ready:     false,
 	}
 
-	_, err = clientset.CoreV1().Namespaces().Get(ctx, "flux-system", metav1.GetOptions{})
-	if err != nil {
+	if _, err := clientset.CoreV1().Namespaces().Get(ctx, "flux-system", metav1.GetOptions{}); err != nil {
 		status.Message = "flux-system namespace not found"
 		return status, nil
 	}
@@ -211,8 +233,13 @@ func (p *FluxProvider) CheckInstalled(ctx context.Context, kubeconfig []byte) (*
 
 	status.Components = make([]ComponentStatus, 0, len(deployments.Items))
 	allReady := true
+	fluxControllers := 0
 
 	for _, deployment := range deployments.Items {
+		if !fluxControllerNames[deployment.Name] {
+			continue
+		}
+		fluxControllers++
 		compStatus := ComponentStatus{
 			Name:  deployment.Name,
 			Ready: deployment.Status.ReadyReplicas > 0,
@@ -224,6 +251,11 @@ func (p *FluxProvider) CheckInstalled(ctx context.Context, kubeconfig []byte) (*
 			allReady = false
 		}
 		status.Components = append(status.Components, compStatus)
+	}
+
+	if fluxControllers == 0 {
+		status.Message = "flux-system namespace exists but no Flux controllers are installed"
+		return status, nil
 	}
 
 	status.Installed = true

--- a/internal/gitops/provider_flux_detect_test.go
+++ b/internal/gitops/provider_flux_detect_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func fluxNamespace() *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "flux-system"}}
+}
+
+func fluxDeployment(name string, readyReplicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "flux-system"},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: readyReplicas},
+	}
+}
+
+// TestDetectFluxStatus covers the detection contract, including the empty
+// flux-system namespace that previously false-positived as healthy.
+func TestDetectFluxStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		objects       []runtime.Object
+		wantInstalled bool
+		wantReady     bool
+	}{
+		{
+			// The e2e-talos fixture: namespace lingers with no controllers.
+			// Must report not-installed, not healthy.
+			name:          "empty flux-system namespace",
+			objects:       []runtime.Object{fluxNamespace()},
+			wantInstalled: false,
+			wantReady:     false,
+		},
+		{
+			name:          "no flux-system namespace",
+			objects:       nil,
+			wantInstalled: false,
+			wantReady:     false,
+		},
+		{
+			name: "fully installed and ready",
+			objects: []runtime.Object{
+				fluxNamespace(),
+				fluxDeployment("source-controller", 1),
+				fluxDeployment("kustomize-controller", 1),
+				fluxDeployment("helm-controller", 1),
+				fluxDeployment("notification-controller", 1),
+			},
+			wantInstalled: true,
+			wantReady:     true,
+		},
+		{
+			// Installed must not collapse into not-installed when a component
+			// is merely unhealthy.
+			name: "installed but not all ready",
+			objects: []runtime.Object{
+				fluxNamespace(),
+				fluxDeployment("source-controller", 1),
+				fluxDeployment("kustomize-controller", 0),
+			},
+			wantInstalled: true,
+			wantReady:     false,
+		},
+		{
+			// A stray non-Flux deployment in flux-system is not a Flux install.
+			name: "namespace with only a non-flux deployment",
+			objects: []runtime.Object{
+				fluxNamespace(),
+				fluxDeployment("some-other-app", 1),
+			},
+			wantInstalled: false,
+			wantReady:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(tt.objects...)
+			status, err := detectFluxStatus(context.Background(), clientset)
+			if err != nil {
+				t.Fatalf("detectFluxStatus returned error: %v", err)
+			}
+			if status.Installed != tt.wantInstalled {
+				t.Errorf("Installed = %v, want %v (message: %q)", status.Installed, tt.wantInstalled, status.Message)
+			}
+			if status.Ready != tt.wantReady {
+				t.Errorf("Ready = %v, want %v (message: %q)", status.Ready, tt.wantReady, status.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`FluxProvider.CheckInstalled` (internal/gitops/provider_flux.go) mistook namespace existence for an install. Once the `flux-system` namespace was found it set `Installed=true` unconditionally and `Ready=allReady`, where `allReady` starts true and is only falsified by iterating deployments. With an empty deployment list the loop never runs, so a leftover empty `flux-system` namespace reported `Installed=true, Ready=true` ("Flux is installed and healthy"). `GetStatus` trusts this, so the cluster GitOps status verb reported a cluster as GitOps-enabled and Healthy when no Flux was present.

## How it surfaced

Found during the butler-cli Feature 2.2 (cluster GitOps lifecycle) end-to-end test against tenant `e2e-talos`. `status` reported `enabled=true, provider=fluxcd, Healthy`, while `preview`/`export` (which detect the engine via Helm-release discovery) correctly returned "No GitOps engine installed." Direct inspection of the tenant confirmed the truth: `flux-system` namespace Active 61d with 0 deployments, 0 resources, 0 toolkit CRDs. So `status` was the false positive, not preview/export.

## The fix

- `Installed` now requires at least one recognized Flux controller Deployment in `flux-system` (`source-controller`, `kustomize-controller`, `helm-controller`, `notification-controller`). An existing namespace alone, or a namespace holding only unrelated deployments, reports not-installed. This matches how Flux actually installs (bootstrap creates these gotk controller deployments) and how preview/export already determine engine presence.
- `Installed` and `Ready` remain distinct: an installed-but-not-all-ready Flux reports `Installed=true, Ready=false`, not absent.
- Detection extracted into `detectFluxStatus(ctx, kubernetes.Interface)` so it is unit-testable with a fake clientset.

## Tests (failure modes)

- Empty `flux-system` namespace (the e2e-talos fixture) -> Installed=false, Ready=false.
- No `flux-system` namespace -> Installed=false.
- Fully installed, all controllers ready -> Installed=true, Ready=true.
- Installed but a controller not ready -> Installed=true, Ready=false (signals do not collapse).
- Namespace with only a non-Flux deployment -> Installed=false.

Verified additionally against the live `e2e-talos` tenant: the fixed detection reports `Installed=false` ("flux-system namespace exists but no Flux controllers are installed"), matching ground truth.

## Follow-up (not in this PR)

Tenant cleanup: delete the lingering empty `flux-system` namespace on `e2e-talos` and audit other tenants for the same leftover state. That is a tenant mutation and is tracked separately.