### PR TITLE
fix(gitops): unify Flux detection behind one shared primitive

### DIFF
--- a/internal/gitops/discovery.go
+++ b/internal/gitops/discovery.go
@@ -297,37 +297,22 @@ func detectGitOpsEngine(ctx context.Context, clientset kubernetes.Interface, dyn
 }
 
 func detectFlux(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface) *GitOpsEngineStatus {
-	deployments, err := clientset.AppsV1().Deployments("flux-system").List(ctx, metav1.ListOptions{})
-	if err != nil || len(deployments.Items) == 0 {
-		return nil
-	}
-
-	var readyComponents []string
-	var version string
-
-	for _, deployment := range deployments.Items {
-		if deployment.Status.ReadyReplicas > 0 {
-			readyComponents = append(readyComponents, deployment.Name)
-
-			if version == "" && len(deployment.Spec.Template.Spec.Containers) > 0 {
-				image := deployment.Spec.Template.Spec.Containers[0].Image
-				if parts := strings.Split(image, ":"); len(parts) > 1 {
-					version = parts[len(parts)-1]
-				}
-			}
-		}
-	}
-
-	if len(readyComponents) < 2 {
+	// Shared detector: Installed = >=1 recognized gotk controller present;
+	// Ready = all present controllers ready. Returning nil only when the engine
+	// is absent keeps the export/preview gate (GitOpsEngine == nil || !Installed)
+	// gating on engine presence, not on readiness -- a partial-but-installed
+	// Flux is exportable because the export path reads API data, not controllers.
+	engine, err := detectFluxEngine(ctx, clientset)
+	if err != nil || !engine.Installed {
 		return nil
 	}
 
 	status := &GitOpsEngineStatus{
 		Provider:   "flux",
 		Installed:  true,
-		Ready:      len(readyComponents) >= 3,
-		Version:    version,
-		Components: readyComponents,
+		Ready:      engine.Ready,
+		Version:    engine.Version,
+		Components: engine.readyComponentNames(),
 	}
 
 	// Populate Repository/Branch/Path from the Flux bootstrap CRs when

--- a/internal/gitops/flux_detect.go
+++ b/internal/gitops/flux_detect.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// fluxControllerNames are the gotk controller Deployments a `flux bootstrap`
+// creates in flux-system. Their presence is the signal that the Flux engine is
+// installed; the namespace existing on its own is not, since a prior bootstrap
+// or uninstall can leave an empty flux-system namespace behind.
+var fluxControllerNames = map[string]bool{
+	"source-controller":       true,
+	"kustomize-controller":    true,
+	"helm-controller":         true,
+	"notification-controller": true,
+}
+
+// FluxEngineStatus is the single source of truth for Flux install/readiness,
+// consumed by both FluxProvider.CheckInstalled (the CLI status verb) and
+// detectFlux (discover, the export/preview gate, and the console banner).
+// Installed and Ready are distinct: a partial install is Installed=true,
+// Ready=false.
+//
+// Installed (not Ready) is what gates export/preview. The export path reads
+// Helm release Secrets, native resources, and Flux bootstrap CRs straight from
+// the API server and needs no Flux controller actually running, so the engine
+// being present is sufficient to export. Ready drives only the healthy vs
+// degraded distinction in status and the console banner.
+type FluxEngineStatus struct {
+	Installed  bool
+	Ready      bool
+	Version    string
+	Components []ComponentStatus
+}
+
+// detectFluxEngine reports Flux install/readiness in flux-system. It takes a
+// kubernetes.Interface so the detection is unit-testable with a fake clientset.
+//
+// Installed requires at least one recognized Flux controller Deployment; an
+// empty or controller-less flux-system namespace reports not-installed. Ready
+// requires every present recognized controller to have a ready replica.
+func detectFluxEngine(ctx context.Context, clientset kubernetes.Interface) (FluxEngineStatus, error) {
+	var status FluxEngineStatus
+
+	// No explicit flux-system namespace check: listing deployments in an absent
+	// namespace returns an empty list, so the controller-count gate below already
+	// covers both "namespace absent" and "namespace present but empty" -> not
+	// installed. A real LIST error (e.g. RBAC) is surfaced.
+	deployments, err := clientset.AppsV1().Deployments("flux-system").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return status, fmt.Errorf("failed to list flux-system deployments: %w", err)
+	}
+
+	allReady := true
+	controllers := 0
+	status.Components = make([]ComponentStatus, 0, len(deployments.Items))
+	for _, deployment := range deployments.Items {
+		if !fluxControllerNames[deployment.Name] {
+			continue
+		}
+		controllers++
+		ready := deployment.Status.ReadyReplicas > 0
+		message := "ready"
+		if !ready {
+			message = "not ready"
+			allReady = false
+		}
+		status.Components = append(status.Components, ComponentStatus{Name: deployment.Name, Ready: ready, Message: message})
+	}
+
+	if controllers == 0 {
+		return status, nil
+	}
+
+	status.Installed = true
+	status.Ready = allReady
+
+	if deployment, err := clientset.AppsV1().Deployments("flux-system").Get(ctx, "source-controller", metav1.GetOptions{}); err == nil && len(deployment.Spec.Template.Spec.Containers) > 0 {
+		if parts := strings.Split(deployment.Spec.Template.Spec.Containers[0].Image, ":"); len(parts) > 1 {
+			status.Version = parts[len(parts)-1]
+		}
+	}
+
+	return status, nil
+}
+
+// readyComponentNames returns the names of the ready Flux controllers, used for
+// the GitOpsEngineStatus.Components "components running" display.
+func (s FluxEngineStatus) readyComponentNames() []string {
+	names := make([]string, 0, len(s.Components))
+	for _, c := range s.Components {
+		if c.Ready {
+			names = append(names, c.Name)
+		}
+	}
+	return names
+}

--- a/internal/gitops/flux_detect_test.go
+++ b/internal/gitops/flux_detect_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+// newFluxDynClient builds a fake dynamic client that knows the Flux bootstrap CR
+// list kinds enrichFluxFromBootstrapCRs reads, so LIST does not panic. The CRs
+// are absent, exercising enrich's graceful empty path (detection is unaffected).
+func newFluxDynClient() *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"}:   "GitRepositoryList",
+		{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}: "KustomizationList",
+	})
+}
+
+func fluxNS() *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "flux-system"}}
+}
+
+func fluxDep(name string, readyReplicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "flux-system"},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: readyReplicas},
+	}
+}
+
+func allFourReady() []runtime.Object {
+	return []runtime.Object{
+		fluxNS(),
+		fluxDep("source-controller", 1),
+		fluxDep("kustomize-controller", 1),
+		fluxDep("helm-controller", 1),
+		fluxDep("notification-controller", 1),
+	}
+}
+
+// TestDetectFluxEngine exercises the shared detector across the install
+// spectrum, including the partial window where the old detectors diverged.
+func TestDetectFluxEngine(t *testing.T) {
+	tests := []struct {
+		name          string
+		objects       []runtime.Object
+		wantInstalled bool
+		wantReady     bool
+	}{
+		{"empty flux-system namespace", []runtime.Object{fluxNS()}, false, false},
+		{"no flux-system namespace", nil, false, false},
+		{"all controllers ready", allFourReady(), true, true},
+		{
+			"partial: 1 of 4 ready",
+			[]runtime.Object{fluxNS(), fluxDep("source-controller", 1), fluxDep("kustomize-controller", 0), fluxDep("helm-controller", 0), fluxDep("notification-controller", 0)},
+			true, false,
+		},
+		{
+			"partial: 3 of 4 ready",
+			[]runtime.Object{fluxNS(), fluxDep("source-controller", 1), fluxDep("kustomize-controller", 1), fluxDep("helm-controller", 1), fluxDep("notification-controller", 0)},
+			true, false,
+		},
+		{
+			"namespace with only a non-flux deployment",
+			[]runtime.Object{fluxNS(), fluxDep("some-other-app", 1)},
+			false, false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := detectFluxEngine(context.Background(), fake.NewSimpleClientset(tt.objects...))
+			if err != nil {
+				t.Fatalf("detectFluxEngine error: %v", err)
+			}
+			if s.Installed != tt.wantInstalled || s.Ready != tt.wantReady {
+				t.Errorf("Installed=%v Ready=%v, want Installed=%v Ready=%v", s.Installed, s.Ready, tt.wantInstalled, tt.wantReady)
+			}
+		})
+	}
+}
+
+// TestStatusDiscoverAgree is the anti-divergence guarantee: the status side
+// (detectFluxEngine, which CheckInstalled wraps) and the discover side
+// (detectFlux) report the SAME installed/ready for the same cluster state.
+func TestStatusDiscoverAgree(t *testing.T) {
+	dyn := newFluxDynClient()
+	states := []struct {
+		name    string
+		objects []runtime.Object
+	}{
+		{"healthy", allFourReady()},
+		{"partial", []runtime.Object{fluxNS(), fluxDep("source-controller", 1), fluxDep("kustomize-controller", 0)}},
+		{"empty-ns", []runtime.Object{fluxNS()}},
+		{"no-ns", nil},
+	}
+	for _, st := range states {
+		t.Run(st.name, func(t *testing.T) {
+			cs := fake.NewSimpleClientset(st.objects...)
+			engine, err := detectFluxEngine(context.Background(), cs)
+			if err != nil {
+				t.Fatalf("detectFluxEngine error: %v", err)
+			}
+			ge := detectFlux(context.Background(), cs, dyn)
+			discoverInstalled := ge != nil && ge.Installed
+			discoverReady := ge != nil && ge.Ready
+			if discoverInstalled != engine.Installed || discoverReady != engine.Ready {
+				t.Errorf("discover(installed=%v ready=%v) != status(installed=%v ready=%v)",
+					discoverInstalled, discoverReady, engine.Installed, engine.Ready)
+			}
+		})
+	}
+}
+
+// TestDetectFluxGate locks in the G3 gate semantics. The export/preview gate is
+// `GitOpsEngine == nil || !Installed`, so detectFlux returns non-nil+Installed
+// exactly when the engine is present (regardless of readiness).
+func TestDetectFluxGate(t *testing.T) {
+	dyn := newFluxDynClient()
+	ctx := context.Background()
+	allowed := func(objs ...runtime.Object) bool {
+		ge := detectFlux(ctx, fake.NewSimpleClientset(objs...), dyn)
+		return ge != nil && ge.Installed
+	}
+
+	// CHANGED -> ALLOWED: a partial install with fewer than 2 ready controllers
+	// was blocked under the old >=2-ready gate; under G3 (engine present) it is
+	// allowed, because export reads API data and needs no controller running.
+	if !allowed(fluxNS(), fluxDep("source-controller", 1), fluxDep("kustomize-controller", 0), fluxDep("helm-controller", 0), fluxDep("notification-controller", 0)) {
+		t.Error("partial Flux (1 of 4 ready) must be ALLOWED under G3")
+	}
+
+	// CHANGED -> BLOCKED: 2 ready non-Flux deployments passed the old
+	// >=2-any-ready gate; under G3 they are not a Flux engine, so blocked.
+	if allowed(fluxNS(), fluxDep("other-a", 1), fluxDep("other-b", 1)) {
+		t.Error("flux-system with only non-Flux deployments must be BLOCKED under G3")
+	}
+
+	// UNCHANGED: empty namespace blocked; healthy allowed.
+	if allowed(fluxNS()) {
+		t.Error("empty flux-system must be BLOCKED")
+	}
+	if !allowed(allFourReady()...) {
+		t.Error("healthy Flux must be ALLOWED")
+	}
+}
+
+// TestDetectFluxEngine_ListErrorPropagates proves a genuine deployment LIST
+// error (e.g. RBAC) is surfaced, not silently mapped to not-installed. Only an
+// absent/empty namespace (an empty list, no error) means not-installed.
+func TestDetectFluxEngine_ListErrorPropagates(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("list", "deployments", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("forbidden")
+	})
+	_, err := detectFluxEngine(context.Background(), cs)
+	if err == nil {
+		t.Error("expected the LIST error to propagate, not be swallowed as not-installed")
+	}
+}

--- a/internal/gitops/provider_flux.go
+++ b/internal/gitops/provider_flux.go
@@ -186,61 +186,33 @@ func (p *FluxProvider) GenerateBootstrapStructure(cfg BootstrapConfig) (map[stri
 	return files, nil
 }
 
-// CheckInstalled verifies Flux is installed on the cluster.
+// CheckInstalled verifies Flux is installed on the cluster. It delegates to the
+// shared detectFluxEngine so the CLI status verb, the export/preview gate, and
+// the console banner all answer "is Flux installed/ready" from one primitive.
 func (p *FluxProvider) CheckInstalled(ctx context.Context, kubeconfig []byte) (*ProviderStatus, error) {
 	clientset, err := createClientset(kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clientset: %w", err)
 	}
 
+	engine, err := detectFluxEngine(ctx, clientset)
+	if err != nil {
+		return nil, err
+	}
+
 	status := &ProviderStatus{
-		Installed: false,
-		Ready:     false,
+		Installed:  engine.Installed,
+		Ready:      engine.Ready,
+		Version:    engine.Version,
+		Components: engine.Components,
 	}
-
-	_, err = clientset.CoreV1().Namespaces().Get(ctx, "flux-system", metav1.GetOptions{})
-	if err != nil {
-		status.Message = "flux-system namespace not found"
-		return status, nil
-	}
-
-	deployments, err := clientset.AppsV1().Deployments("flux-system").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list flux-system deployments: %w", err)
-	}
-
-	status.Components = make([]ComponentStatus, 0, len(deployments.Items))
-	allReady := true
-
-	for _, deployment := range deployments.Items {
-		compStatus := ComponentStatus{
-			Name:  deployment.Name,
-			Ready: deployment.Status.ReadyReplicas > 0,
-		}
-		if compStatus.Ready {
-			compStatus.Message = "ready"
-		} else {
-			compStatus.Message = "not ready"
-			allReady = false
-		}
-		status.Components = append(status.Components, compStatus)
-	}
-
-	status.Installed = true
-	status.Ready = allReady
-
-	if allReady {
+	switch {
+	case !engine.Installed:
+		status.Message = "Flux is not installed (no Flux controllers in flux-system)"
+	case engine.Ready:
 		status.Message = "Flux is installed and healthy"
-	} else {
+	default:
 		status.Message = "Flux is installed but some components are not ready"
-	}
-
-	deployment, err := clientset.AppsV1().Deployments("flux-system").Get(ctx, "source-controller", metav1.GetOptions{})
-	if err == nil && len(deployment.Spec.Template.Spec.Containers) > 0 {
-		image := deployment.Spec.Template.Spec.Containers[0].Image
-		if parts := strings.Split(image, ":"); len(parts) > 1 {
-			status.Version = parts[len(parts)-1]
-		}
 	}
 
 	return status, nil


### PR DESCRIPTION
## Problem

"Is Flux installed/ready" was answered by two different algorithms that diverged on partial installs:
- **status** (`FluxProvider.CheckInstalled`) keyed on the `flux-system` namespace existing -> false-positive "healthy" on an empty/leftover namespace.
- **discover/preview/export** (`detectFlux`) required >=2 *ready* deployments, counting **any** deployment in `flux-system` (not gotk-filtered).

## Change

Introduce `detectFluxEngine(ctx, kubernetes.Interface)` as the single source of truth, consumed by both `CheckInstalled` (CLI status) and `detectFlux` (discover, the export/preview gate, the console banner):
- **Installed** = at least one recognized gotk controller Deployment present (`source/kustomize/helm/notification-controller`).
- **Ready** = every present recognized controller has a ready replica.
- Installed and Ready are **distinct**: a partial install is `Installed=true, Ready=false`.

Flux divergence is now structurally impossible: `detectFluxEngine` is the only code path that computes Flux installed/ready.

## Gate correctness fix (G3): gate on Installed, not readiness

Export/preview gate on engine **presence** (`Installed`), not readiness. The export path reads Helm release Secrets, native resources, and Flux bootstrap CRs straight from the API server and depends on **no Flux controller actually running**, so engine-present is the correct precondition. The gate expression (`GitOpsEngine == nil || !Installed`) is unchanged; only the meaning of `Installed` is corrected.

**Exact change set vs the old >=2-ready gate (three cases change):**
1. **1-ready partial, and 0-ready-but-controllers-present: BLOCK -> ALLOW.** Now correctly exportable (export needs the engine present, not ready).
2. **`flux-system` with only non-Flux deployments: wrongly-ALLOW -> correctly-BLOCK** (old counted any 2 ready; G3 requires recognized gotk controllers).
3. **2-3-ready partial: was already ALLOWED (>=2 ready), stays ALLOWED.**
   (healthy stays allowed; empty-ns and no-ns stay blocked.)

Removed the redundant `flux-system` namespace existence check: a LIST in a nonexistent namespace returns an empty list, so the controller-count gate already covers "namespace absent" and "namespace present but empty" -> not-installed. A genuine LIST error is surfaced (detectFlux maps it to nil as before; CheckInstalled propagates it as before).

## Supersedes #85

The standalone status-side fix (#85) folds in here; its semantics become the shared definition. Close #85 in favor of this PR when this merges.

## Console: no companion PR needed

The console already renders the partial state: both GitOps banners render `installed && !ready` as "Installed" + a yellow "Degraded" badge, and gate export/migrate UI on `isGitOpsInstalled` (not on `ready`). PR-1 only activates that state; the existing UI is forward-compatible. No console code change.

## ArgoCD (follow-up, not in this PR)

ArgoCD still has the same two-detector split Flux just escaped: `detectArgoCD` (discover) uses >=2-ready/>=3-ready while `ArgoCDProvider.CheckInstalled` (status) uses argocd-namespace-existence + allReady (the same empty-namespace false-positive shape the old Flux status had). Not introduced here; flagged for a follow-up `detectArgoCDEngine` mirroring `detectFluxEngine`. Left out because it is non-trivial (statefulset handling, different components) and ArgoCD may be unused.

## Tests

- `detectFluxEngine` across the spectrum: empty-ns, no-ns, all-ready, partial 1-of-4, partial 3-of-4, only-non-Flux-deployment.
- **Anti-divergence:** status side and discover side return the same `Installed`/`Ready` for the same state.
- **Gate (G3):** partial <2-ready now ALLOWED; only-non-Flux-deployments now BLOCKED; empty-ns blocked; healthy allowed.