### PR TITLE
fix(gitops): treat api.github.com as public GitHub for flux bootstrap

### DIFF
--- a/internal/gitops/compat.go
+++ b/internal/gitops/compat.go
@@ -28,9 +28,16 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// HostnameFromURL extracts the hostname from a URL string.
-// Returns empty string for empty input or the well-known defaults
-// (github.com, gitlab.com) since flux uses those by default.
+// HostnameFromURL extracts the flux-bootstrap hostname from a git provider URL.
+// It returns "" for the public SaaS hosts so flux uses its built-in defaults,
+// and the real hostname only for genuine self-hosted/Enterprise installs.
+//
+// api.github.com is included because the GitHub gitops config URL is set to the
+// API host (to avoid being treated as GitHub Enterprise), but flux bootstrap
+// needs the git host, not the API host -- passing api.github.com as --hostname
+// makes flux build the remote against api.github.com/owner/repo and fail owner
+// lookup. The match is exact equality, so an Enterprise host that merely
+// contains "github" (e.g. github.mycorp.com) is preserved, not collapsed to "".
 func HostnameFromURL(rawURL string) string {
 	if rawURL == "" {
 		return ""
@@ -40,7 +47,10 @@ func HostnameFromURL(rawURL string) string {
 		return ""
 	}
 	host := u.Hostname()
-	if strings.EqualFold(host, "github.com") || strings.EqualFold(host, "gitlab.com") {
+	switch {
+	case strings.EqualFold(host, "github.com"),
+		strings.EqualFold(host, "api.github.com"),
+		strings.EqualFold(host, "gitlab.com"):
 		return ""
 	}
 	return host

--- a/internal/gitops/compat_test.go
+++ b/internal/gitops/compat_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import "testing"
+
+func TestHostnameFromURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		// The bug: the GitHub gitops config URL is the API host, which flux
+		// must NOT receive as --hostname. Returns "" so flux uses github.com.
+		{"github api host", "https://api.github.com", ""},
+		{"github api host uppercase", "https://API.GitHub.com", ""},
+		// Public SaaS hosts already mapped to "" (no regression).
+		{"github.com", "https://github.com", ""},
+		{"gitlab.com", "https://gitlab.com", ""},
+		// Inverse failure mode: genuine Enterprise / self-hosted hosts MUST
+		// keep their real hostname; the exact-match must not collapse a host
+		// that merely contains "github"/"gitlab".
+		{"github enterprise", "https://github.mycorp.com", "github.mycorp.com"},
+		{"gitlab self-hosted", "https://gitlab.mycorp.com", "gitlab.mycorp.com"},
+		{"enterprise with github substring", "https://github.example.org", "github.example.org"},
+		// Degenerate inputs.
+		{"empty", "", ""},
+		{"unparseable", "://bad", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HostnameFromURL(tt.url); got != tt.want {
+				t.Errorf("HostnameFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

`cluster gitops enable` returns 500 for standard GitHub, on both CLI and console:

```
flux bootstrap failed: connecting to api.github.com
failed to create new Git repository "https://api.github.com/<owner>/<repo>": unable to get owner from API
```

The GitHub gitops config URL is set to `https://api.github.com` (the API host, so the server does not treat it as GitHub Enterprise). `HostnameFromURL` mapped only `github.com` and `gitlab.com` to `""` (flux's built-in public host), so for `api.github.com` it returned `"api.github.com"`. butler-server passes that as flux bootstrap's `--hostname`, so flux builds the **git remote** against the **API host** (`api.github.com/owner/repo`) and fails owner lookup.

Found while running the Feature 2.2 (cluster GitOps lifecycle) E2E: `enable` could not install Flux, which blocks the downstream verbs.

## Fix

Map `api.github.com` to `""` alongside `github.com`/`gitlab.com`, via **exact equality**.

## Enterprise/self-hosted preserved (the inverse failure mode)

The match is exact equality, so a genuine Enterprise or self-hosted host that merely contains "github"/"gitlab" keeps its real hostname and is **not** collapsed to `""`:
- `https://api.github.com` -> `""` (the fix)
- `https://github.com` / `https://gitlab.com` -> `""` (unchanged)
- `https://github.mycorp.com` -> `github.mycorp.com` (Enterprise preserved)
- `https://gitlab.mycorp.com` -> `gitlab.mycorp.com` (self-hosted preserved)

A table-driven test covers these; the Enterprise-preserved cases are the inverse-failure-mode evidence (a substring match would fail them).

## Scope

`HostnameFromURL` (compat.go) + its test only. The CLI `--repo` help text says "URL" but the server expects `owner/repo` (the GitHub fullName) -- a separate doc caveat that rides the Feature 2.2 CLI ship, not this server PR.