### PR TITLE
feat(auth): add portal-JWT verification path behind feature flag

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -235,12 +235,34 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) {
 	stewardHandler := handlers.NewStewardHandler(cfg.K8sClient, cfg.Config)
 	auditHandler := handlers.NewAuditHandler(auditEmitter)
 
+	// Portal verifier is constructed only when an Ed25519 public key is
+	// configured. Stage 1 default ships with BUTLER_PORTAL_PUBKEY unset, so
+	// the verifier is nil and SessionMiddleware's portal branch stays
+	// dormant. Stage 2 onward sets the pubkey via the same env var.
+	var portalVerifier *auth.PortalJWTVerifier
+	if pemData := cfg.Config.Auth.PortalPubKey; pemData != "" {
+		keys, err := auth.ParsePortalPublicKeysPEM(pemData)
+		if err != nil {
+			cfg.Logger.Error("BUTLER_PORTAL_PUBKEY parse failed", "error", err)
+		} else {
+			verifier, err := auth.NewPortalJWTVerifier(keys, userService)
+			if err != nil {
+				cfg.Logger.Error("portal verifier construction failed", "error", err)
+			} else {
+				portalVerifier = verifier
+				cfg.Logger.Info("Portal JWT verifier ready", "keys", len(keys))
+			}
+		}
+	}
+
 	// Auth middleware - SECURITY: Now re-validates team membership on every request
 	authMiddleware := auth.SessionMiddleware(auth.SessionMiddlewareConfig{
-		SessionService: sessionService,
-		TeamResolver:   teamResolver,
-		UserService:    userService,
-		Logger:         cfg.Logger.With("component", "auth-middleware"),
+		SessionService:           sessionService,
+		TeamResolver:             teamResolver,
+		UserService:              userService,
+		Logger:                   cfg.Logger.With("component", "auth-middleware"),
+		PortalVerifier:           portalVerifier,
+		AllowHeaderImpersonation: cfg.Config.Auth.AllowHeaderImpersonation,
 	})
 	adminMiddleware := auth.AdminMiddleware()
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -39,6 +39,20 @@ type SessionMiddlewareConfig struct {
 	TeamResolver   *TeamResolver
 	UserService    *UserService // Added: for checking disabled status
 	Logger         *slog.Logger
+
+	// PortalVerifier is the Ed25519 portal-proof validator. When non-nil it
+	// routes tokens whose iss claim is PortalJWTIssuer to portal-JWT
+	// verification; all other tokens fall through to SessionService.
+	// Stage 1 default: nil (path dormant). Stage 2 onward sets this in
+	// production so portal-mediated requests authenticate via signed proofs.
+	PortalVerifier *PortalJWTVerifier
+
+	// AllowHeaderImpersonation gates the legacy X-Butler-User-Email override
+	// inside the platform-admin branch. true preserves the pre-Stage-1
+	// behavior (the portal proxy's current carrier). Stage 4 flips this to
+	// false; the impersonation sub-block is removed entirely in the
+	// follow-up cleanup PR after soak.
+	AllowHeaderImpersonation bool
 }
 
 // SessionMiddleware validates the session token and re-resolves team membership on every request.
@@ -69,11 +83,38 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 				return
 			}
 
-			// Validate session
-			user, err := cfg.SessionService.ValidateSession(token)
-			if err != nil {
-				http.Error(w, `{"error":"invalid session"}`, http.StatusUnauthorized)
-				return
+			// Validate session. Route portal-issued Ed25519 proofs (iss=
+			// PortalJWTIssuer) to the portal verifier; every other token
+			// shape (console HMAC sessions, CLI device-flow sessions,
+			// legacy admin sessions) falls through to SessionService
+			// UNCHANGED. The iss-gate inside MaybeVerify is what keeps
+			// non-portal callers byte-identical under this branch.
+			var user *UserSession
+			if cfg.PortalVerifier != nil {
+				portalSess, claimed, perr := cfg.PortalVerifier.MaybeVerify(r.Context(), token)
+				if perr != nil {
+					// Token claimed the portal-proof shape (iss=
+					// PortalJWTIssuer) but failed verification. Reject
+					// the request rather than fall through: handing the
+					// same bytes to SessionService would re-reject under
+					// a misleading reason and obscure the failure.
+					if cfg.Logger != nil {
+						cfg.Logger.Warn("Portal proof rejected", "error", perr)
+					}
+					http.Error(w, `{"error":"invalid portal proof"}`, http.StatusUnauthorized)
+					return
+				}
+				if claimed {
+					user = portalSess
+				}
+			}
+			if user == nil {
+				sess, err := cfg.SessionService.ValidateSession(token)
+				if err != nil {
+					http.Error(w, `{"error":"invalid session"}`, http.StatusUnauthorized)
+					return
+				}
+				user = sess
 			}
 
 			// Read team context from header (sent by frontend when scoped to a team)
@@ -93,14 +134,20 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 				// server can use it as the effective identity (e.g., workspace
 				// ownership, SSH key resolution). Only trust this header for
 				// platform admin sessions to prevent unprivileged impersonation.
-				if impersonateEmail := r.Header.Get("X-Butler-User-Email"); impersonateEmail != "" {
-					if cfg.Logger != nil {
-						cfg.Logger.Debug("Platform admin impersonating user via X-Butler-User-Email",
-							"sessionEmail", user.Email,
-							"effectiveEmail", impersonateEmail,
-						)
+				//
+				// AllowHeaderImpersonation is the Stage 1 back-compat flag:
+				// default true preserves the current behavior; Stage 4 flips
+				// to false ahead of the cleanup PR that deletes this block.
+				if cfg.AllowHeaderImpersonation {
+					if impersonateEmail := r.Header.Get("X-Butler-User-Email"); impersonateEmail != "" {
+						if cfg.Logger != nil {
+							cfg.Logger.Debug("Platform admin impersonating user via X-Butler-User-Email",
+								"sessionEmail", user.Email,
+								"effectiveEmail", impersonateEmail,
+							)
+						}
+						user.Email = impersonateEmail
 					}
-					user.Email = impersonateEmail
 				}
 
 				// Set team context if provided - this enables team-scoped authorization

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -33,6 +33,17 @@ func UserFromContext(ctx context.Context) *UserSession {
 	return user
 }
 
+// PortalProofVerifier is the minimum interface SessionMiddleware needs from
+// a portal-proof validator. The interface seam exists so the claimed-is-
+// terminal guard inside SessionMiddleware has a testable boundary: a stub
+// verifier returning (nil, true, nil) lets the test assert the middleware
+// rejects rather than falls through, without depending on internal details
+// of any concrete verifier implementation. *PortalJWTVerifier satisfies
+// this interface.
+type PortalProofVerifier interface {
+	MaybeVerify(ctx context.Context, token string) (*UserSession, bool, error)
+}
+
 // SessionMiddlewareConfig holds dependencies for the session middleware.
 type SessionMiddlewareConfig struct {
 	SessionService *SessionService
@@ -45,7 +56,7 @@ type SessionMiddlewareConfig struct {
 	// verification; all other tokens fall through to SessionService.
 	// Stage 1 default: nil (path dormant). Stage 2 onward sets this in
 	// production so portal-mediated requests authenticate via signed proofs.
-	PortalVerifier *PortalJWTVerifier
+	PortalVerifier PortalProofVerifier
 
 	// AllowHeaderImpersonation gates the legacy X-Butler-User-Email override
 	// inside the platform-admin branch. true preserves the pre-Stage-1
@@ -105,6 +116,24 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 					return
 				}
 				if claimed {
+					if portalSess == nil {
+						// Claimed-is-terminal invariant. When MaybeVerify
+						// reports claimed=true the session must be non-nil
+						// OR the perr branch above must have returned.
+						// Honoring claimed=true with a nil session here
+						// would let a portal-claimed token fall through to
+						// ValidateSession and get a second chance at HMAC
+						// auth, which is the bypass shape this guard
+						// backstops. Enforce the invariant at the
+						// middleware boundary so a future refactor of the
+						// verifier internals cannot open that path
+						// silently.
+						if cfg.Logger != nil {
+							cfg.Logger.Warn("Portal proof verifier returned claimed without session")
+						}
+						http.Error(w, `{"error":"invalid portal proof"}`, http.StatusUnauthorized)
+						return
+					}
 					user = portalSess
 				}
 			}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -420,3 +420,43 @@ func TestSessionMiddleware_AllowHeaderImpersonationFalse_HeaderIgnored(t *testin
 		t.Errorf("downstream saw email=%q want %q (override must NOT fire with flag false)", got, adminMail)
 	}
 }
+
+// stubVerifier returns prescribed (session, claimed, err) shapes to exercise
+// SessionMiddleware's claimed-is-terminal invariant directly. It does not
+// look at the token bytes; the test injects the desired return shape and
+// drives the middleware with arbitrary Bearer content.
+type stubVerifier struct {
+	session *UserSession
+	claimed bool
+	err     error
+}
+
+func (s *stubVerifier) MaybeVerify(_ context.Context, _ string) (*UserSession, bool, error) {
+	return s.session, s.claimed, s.err
+}
+
+func TestSessionMiddleware_ClaimedWithNilSession_RejectsTerminal(t *testing.T) {
+	// Claimed-is-terminal invariant. If a verifier ever returns (nil, true,
+	// nil) the middleware MUST reject rather than fall through to
+	// ValidateSession. The fall-through would give a portal-claimed token a
+	// second chance at HMAC auth, which is the bypass shape this guard
+	// backstops. The body-string assertion is what makes this test non-
+	// vacuous: both the guard path and the ValidateSession path return 401,
+	// but only the guard returns "invalid portal proof".
+	cfg := SessionMiddlewareConfig{
+		SessionService:           NewSessionService("test-secret", time.Hour),
+		PortalVerifier:           &stubVerifier{session: nil, claimed: true, err: nil},
+		AllowHeaderImpersonation: true,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req.Header.Set("Authorization", "Bearer arbitrary-token-bytes")
+	rec := runMiddleware(t, cfg, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status=%d want 401 (claimed without session must be terminal)", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "invalid portal proof") {
+		t.Errorf("body=%q want 'invalid portal proof' response, not the fall-through 'invalid session' from ValidateSession", body)
+	}
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -18,9 +18,14 @@ package auth
 
 import (
 	"context"
+	"crypto/ed25519"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // withUser injects a UserSession into the request context for middleware tests.
@@ -169,5 +174,249 @@ func TestRequireTeam_MemberPasses(t *testing.T) {
 	mw.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Errorf("got %d, want 200", rec.Code)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// SessionMiddleware end-to-end tests covering the portal-JWT branch and the
+// AllowHeaderImpersonation flag (Stage 1 of the P0 #3 fix).
+//
+// Load-bearing invariants:
+//
+//  (i)  with PortalVerifier=nil and AllowHeaderImpersonation=true (the Stage 1
+//       defaults), butler-server behaves byte-identically to pre-Stage-1 for
+//       every existing caller. The console-style JWT path test below proves
+//       this for the console.
+//
+//  (ii) the portal-JWT branch is gated on iss claim. A token whose iss is
+//       anything other than PortalJWTIssuer falls through to ValidateSession
+//       UNCHANGED. The mutation-proof test below (an HS256 session JWT with
+//       iss="butler-server") would fail if the iss gate were widened.
+//
+//  (iii) AllowHeaderImpersonation false skips the X-Butler-User-Email override
+//       in the platform-admin branch even when the header is set. Paired with
+//       the AllowHeaderImpersonation=true test, this proves the flag actually
+//       controls the override (non-vacuous).
+// -----------------------------------------------------------------------------
+
+// runMiddleware constructs SessionMiddleware with the given config and a
+// downstream handler that writes the in-context UserSession.Email to the
+// response body, then drives a single request.
+func runMiddleware(t *testing.T, cfg SessionMiddlewareConfig, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	mw := SessionMiddleware(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := UserFromContext(r.Context())
+		if u == nil {
+			http.Error(w, `{"error":"no-user"}`, http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(u.Email))
+	}))
+	mw.ServeHTTP(rec, req)
+	return rec
+}
+
+func mintConsoleSessionToken(t *testing.T, secret, email string, role string) string {
+	t.Helper()
+	svc := NewSessionService(secret, time.Hour)
+	tok, err := svc.CreateSession(&UserSession{
+		Email:        email,
+		Name:         "Tester",
+		PlatformRole: role,
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return tok
+}
+
+func TestSessionMiddleware_NoPortalVerifier_ConsoleJWTPassesThrough(t *testing.T) {
+	const (
+		secret = "test-jwt-secret"
+		email  = "console-user@example.com"
+	)
+	cfg := SessionMiddlewareConfig{
+		SessionService:           NewSessionService(secret, time.Hour),
+		AllowHeaderImpersonation: true,
+	}
+	tok := mintConsoleSessionToken(t, secret, email, RoleAdmin)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := runMiddleware(t, cfg, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q want 200", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != email {
+		t.Errorf("downstream saw email=%q want %q", got, email)
+	}
+}
+
+func TestSessionMiddleware_PortalVerifier_NonPortalIssJWTFallsThrough(t *testing.T) {
+	// LOAD-BEARING. Confirms the iss gate inside MaybeVerify keeps
+	// console-issued JWTs (iss="butler-server") on the existing
+	// ValidateSession path even when the portal verifier is configured.
+	// Mutation: if the iss gate were widened to accept any iss, the
+	// portal verifier would try to validate the HS256-signed console
+	// JWT as EdDSA, fail, and the middleware would 401. This test
+	// would then fail on the status check.
+	const (
+		secret = "test-jwt-secret"
+		email  = "console-user@example.com"
+	)
+	_, pub, priv := testKeyPair(t)
+	users := &fakeUserResolver{
+		byEmail: map[string]*UserInfo{
+			email: {Name: "u", Email: email, PlatformRole: RoleAdmin},
+		},
+	}
+	verifier, err := NewPortalJWTVerifier(map[string]ed25519.PublicKey{"k1": pub}, users)
+	if err != nil {
+		t.Fatalf("verifier: %v", err)
+	}
+	_ = priv // unused; we deliberately mint a console-style token here, not a portal proof
+
+	cfg := SessionMiddlewareConfig{
+		SessionService:           NewSessionService(secret, time.Hour),
+		PortalVerifier:           verifier,
+		AllowHeaderImpersonation: true,
+	}
+	tok := mintConsoleSessionToken(t, secret, email, RoleAdmin)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := runMiddleware(t, cfg, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q want 200 (console JWT must fall through)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != email {
+		t.Errorf("downstream saw email=%q want %q", got, email)
+	}
+}
+
+func TestSessionMiddleware_PortalProofValid_AuthsAsSub(t *testing.T) {
+	const portalEmail = "portal-user@example.com"
+	kid, pub, priv := testKeyPair(t)
+	users := &fakeUserResolver{
+		byEmail: map[string]*UserInfo{
+			portalEmail: {
+				Name:         "portal-user",
+				Email:        portalEmail,
+				DisplayName:  "Portal User",
+				PlatformRole: RoleAdmin,
+			},
+		},
+	}
+	verifier, _ := NewPortalJWTVerifier(map[string]ed25519.PublicKey{kid: pub}, users)
+	cfg := SessionMiddlewareConfig{
+		SessionService:           NewSessionService("unused", time.Hour),
+		PortalVerifier:           verifier,
+		AllowHeaderImpersonation: true,
+	}
+
+	proof := signProof(t, priv, kid, func(c *jwt.RegisteredClaims, _ *jwt.Token) {
+		c.Subject = portalEmail
+		c.ID = "jti-portal-mw"
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req.Header.Set("Authorization", "Bearer "+proof)
+	rec := runMiddleware(t, cfg, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q want 200", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != portalEmail {
+		t.Errorf("downstream saw email=%q want %q", got, portalEmail)
+	}
+}
+
+func TestSessionMiddleware_PortalProofBadSig_Rejects401(t *testing.T) {
+	kid, pub, priv := testKeyPair(t)
+	users := &fakeUserResolver{
+		byEmail: map[string]*UserInfo{
+			"portal-user@example.com": {
+				Name: "u", Email: "portal-user@example.com", PlatformRole: RoleAdmin,
+			},
+		},
+	}
+	verifier, _ := NewPortalJWTVerifier(map[string]ed25519.PublicKey{kid: pub}, users)
+	cfg := SessionMiddlewareConfig{
+		SessionService:           NewSessionService("unused", time.Hour),
+		PortalVerifier:           verifier,
+		AllowHeaderImpersonation: true,
+	}
+
+	proof := signProof(t, priv, kid, func(c *jwt.RegisteredClaims, _ *jwt.Token) {
+		c.Subject = "portal-user@example.com"
+		c.ID = "jti-bad-sig-mw"
+	})
+	// Tamper the signature.
+	parts := strings.Split(proof, ".")
+	parts[2] = "AAAA" + parts[2][4:]
+	tampered := strings.Join(parts, ".")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req.Header.Set("Authorization", "Bearer "+tampered)
+	rec := runMiddleware(t, cfg, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status=%d want 401 (tampered portal proof must be rejected, not fall through)", rec.Code)
+	}
+}
+
+func TestSessionMiddleware_AllowHeaderImpersonationTrue_HeaderOverrides(t *testing.T) {
+	// Back-compat under Stage 1 default. The platform-admin path reads
+	// X-Butler-User-Email and the override fires.
+	const (
+		secret    = "test-jwt-secret"
+		adminMail = "admin@example.com"
+		spoofMail = "victim@example.com"
+	)
+	cfg := SessionMiddlewareConfig{
+		SessionService:           NewSessionService(secret, time.Hour),
+		AllowHeaderImpersonation: true,
+	}
+	tok := mintConsoleSessionToken(t, secret, adminMail, RoleAdmin)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("X-Butler-User-Email", spoofMail)
+	rec := runMiddleware(t, cfg, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q want 200", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != spoofMail {
+		t.Errorf("downstream saw email=%q want %q (override should fire with flag true)", got, spoofMail)
+	}
+}
+
+func TestSessionMiddleware_AllowHeaderImpersonationFalse_HeaderIgnored(t *testing.T) {
+	// Stage 4 target behavior. Same setup as the back-compat test, but
+	// the flag flips to false. The override MUST NOT fire.
+	const (
+		secret    = "test-jwt-secret"
+		adminMail = "admin@example.com"
+		spoofMail = "victim@example.com"
+	)
+	cfg := SessionMiddlewareConfig{
+		SessionService:           NewSessionService(secret, time.Hour),
+		AllowHeaderImpersonation: false,
+	}
+	tok := mintConsoleSessionToken(t, secret, adminMail, RoleAdmin)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("X-Butler-User-Email", spoofMail)
+	rec := runMiddleware(t, cfg, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q want 200", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != adminMail {
+		t.Errorf("downstream saw email=%q want %q (override must NOT fire with flag false)", got, adminMail)
 	}
 }

--- a/internal/auth/portal_jwt.go
+++ b/internal/auth/portal_jwt.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Portal-proof routing and validation constants. The portal-issued JWT carries
+// iss=PortalJWTIssuer so SessionMiddleware can distinguish portal-mediated
+// requests from console/CLI sessions and route them to PortalJWTVerifier.
+// Any token with a different iss falls through to SessionService.ValidateSession
+// unchanged, which is the property that keeps non-portal callers untouched.
+const (
+	PortalJWTIssuer   = "butler-portal"
+	PortalJWTAudience = "butler-server"
+	PortalJWTMaxTTL   = 60 * time.Second
+)
+
+// PortalUserResolver looks up a user by email. UserService satisfies this.
+// Defined as an interface so tests can inject a fake without standing up the
+// K8s dynamic client.
+type PortalUserResolver interface {
+	GetUserByEmail(ctx context.Context, email string) (*UserInfo, error)
+}
+
+// PortalJWTVerifier verifies portal-issued Ed25519 JWTs and resolves them
+// to a per-request UserSession backed by the User CRD.
+//
+// The verifier is scoped to the portal-proof identity path. It does not
+// validate console sessions or any other token shape: MaybeVerify returns
+// (nil, false, nil) for tokens whose iss claim is not PortalJWTIssuer, so
+// the middleware caller can fall through to the existing SessionService
+// validation unchanged.
+//
+// Multiple public keys are supported via the kid header to enable key
+// rotation: the portal mints with one kid, the server verifies against the
+// matching key in the map.
+type PortalJWTVerifier struct {
+	publicKeys  map[string]ed25519.PublicKey
+	users       PortalUserResolver
+	replayCache *jtiReplayCache
+	now         func() time.Time
+}
+
+// NewPortalJWTVerifier constructs a verifier. publicKeys is keyed by kid.
+// At least one key is required; users must be non-nil for sub resolution.
+func NewPortalJWTVerifier(publicKeys map[string]ed25519.PublicKey, users PortalUserResolver) (*PortalJWTVerifier, error) {
+	if len(publicKeys) == 0 {
+		return nil, errors.New("portal verifier requires at least one public key")
+	}
+	if users == nil {
+		return nil, errors.New("portal verifier requires a user resolver")
+	}
+	for kid, pk := range publicKeys {
+		if kid == "" {
+			return nil, errors.New("portal verifier rejects empty kid")
+		}
+		if len(pk) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("portal verifier key %q has wrong size", kid)
+		}
+	}
+	return &PortalJWTVerifier{
+		publicKeys:  publicKeys,
+		users:       users,
+		replayCache: newJTIReplayCache(10 * time.Minute),
+		now:         time.Now,
+	}, nil
+}
+
+// ParsePortalPublicKeysPEM parses one or more PEM blocks containing
+// Ed25519 public keys in SPKI form. Each block's kid is derived from the
+// (kid="...") header line if present, otherwise from a stable fingerprint
+// of the key bytes. Stage 1 ships with a single key; the map shape exists
+// for Stage 4+ rotation work.
+func ParsePortalPublicKeysPEM(pemData string) (map[string]ed25519.PublicKey, error) {
+	keys := make(map[string]ed25519.PublicKey)
+	rest := []byte(pemData)
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "PUBLIC KEY" {
+			continue
+		}
+		parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse portal public key: %w", err)
+		}
+		pk, ok := parsed.(ed25519.PublicKey)
+		if !ok {
+			return nil, errors.New("portal public key is not Ed25519")
+		}
+		kid := block.Headers["kid"]
+		if kid == "" {
+			kid = fingerprintKid(pk)
+		}
+		keys[kid] = pk
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("no Ed25519 public keys found in PEM input")
+	}
+	return keys, nil
+}
+
+// fingerprintKid derives a short stable kid from the public key bytes when
+// no kid header is supplied in the PEM block. Hex-encoded first 8 bytes of
+// the raw public key; collision-resistant enough for at most a few rotation
+// generations.
+func fingerprintKid(pk ed25519.PublicKey) string {
+	const hex = "0123456789abcdef"
+	out := make([]byte, 16)
+	for i := 0; i < 8 && i < len(pk); i++ {
+		out[i*2] = hex[pk[i]>>4]
+		out[i*2+1] = hex[pk[i]&0x0f]
+	}
+	return string(out)
+}
+
+// MaybeVerify routes a Bearer token. Returns (session, true, nil) when the
+// token is a verified portal proof; (nil, false, nil) when the token is NOT
+// claimed by the portal path (caller should fall through to its existing
+// validator); (nil, true, err) when the token IS claimed as a portal proof
+// but failed verification (caller MUST reject the request rather than
+// fall through).
+//
+// The (claimed) bit lets the middleware distinguish "different token shape,
+// not my problem" from "I claim authority over this token and rejected it."
+// Falling through after a claimed-but-failed portal proof would silently
+// hand the token to SessionService.ValidateSession, which would interpret
+// the same bytes as an HMAC session and reject it for a different reason;
+// callers MUST surface the original rejection.
+func (v *PortalJWTVerifier) MaybeVerify(ctx context.Context, tokenString string) (*UserSession, bool, error) {
+	if v == nil || len(v.publicKeys) == 0 {
+		return nil, false, nil
+	}
+
+	parser := jwt.NewParser(jwt.WithValidMethods([]string{"EdDSA"}))
+	unverified, _, err := parser.ParseUnverified(tokenString, &jwt.RegisteredClaims{})
+	if err != nil {
+		// Token isn't parseable as an Ed25519 JWT (or isn't a JWT at all);
+		// not a portal proof. Fall through.
+		return nil, false, nil
+	}
+	claims, ok := unverified.Claims.(*jwt.RegisteredClaims)
+	if !ok {
+		return nil, false, nil
+	}
+	if claims.Issuer != PortalJWTIssuer {
+		return nil, false, nil
+	}
+
+	session, err := v.verifyClaimed(ctx, tokenString)
+	return session, true, err
+}
+
+func (v *PortalJWTVerifier) verifyClaimed(ctx context.Context, tokenString string) (*UserSession, error) {
+	var claims jwt.RegisteredClaims
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{"EdDSA"}),
+		jwt.WithIssuer(PortalJWTIssuer),
+		jwt.WithAudience(PortalJWTAudience),
+	)
+	token, err := parser.ParseWithClaims(tokenString, &claims, func(t *jwt.Token) (interface{}, error) {
+		kid, _ := t.Header["kid"].(string)
+		if kid == "" {
+			return nil, errors.New("portal proof missing kid header")
+		}
+		pk, found := v.publicKeys[kid]
+		if !found {
+			return nil, fmt.Errorf("portal proof kid %q not configured", kid)
+		}
+		return pk, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("portal proof verification failed: %w", err)
+	}
+	if !token.Valid {
+		return nil, errors.New("portal proof not valid")
+	}
+
+	if claims.IssuedAt == nil || claims.ExpiresAt == nil {
+		return nil, errors.New("portal proof missing iat or exp")
+	}
+	iat := claims.IssuedAt.Time
+	exp := claims.ExpiresAt.Time
+	if ttl := exp.Sub(iat); ttl > PortalJWTMaxTTL+5*time.Second {
+		return nil, fmt.Errorf("portal proof TTL %s exceeds maximum %s", ttl, PortalJWTMaxTTL)
+	}
+
+	now := v.now()
+	if now.After(exp) {
+		return nil, errors.New("portal proof expired")
+	}
+	if claims.NotBefore != nil && now.Before(claims.NotBefore.Time) {
+		return nil, errors.New("portal proof not yet valid")
+	}
+
+	if claims.ID == "" {
+		return nil, errors.New("portal proof missing jti")
+	}
+	if !v.replayCache.checkAndStore(claims.ID, exp) {
+		return nil, errors.New("portal proof jti replayed")
+	}
+
+	sub := strings.TrimSpace(claims.Subject)
+	if sub == "" {
+		return nil, errors.New("portal proof missing sub")
+	}
+	sub = NormalizeEmail(sub)
+
+	userInfo, err := v.users.GetUserByEmail(ctx, sub)
+	if err != nil {
+		return nil, fmt.Errorf("portal proof sub not resolvable to user: %w", err)
+	}
+	if userInfo.Disabled {
+		return nil, ErrUserDisabled
+	}
+
+	// PlatformRole derives from the User CRD spec. IsPlatformAdmin is the
+	// back-compat field SessionService.CreateSession populates from the same
+	// source; mirror that here so downstream consumers (UserSession.IsAdmin()
+	// helpers, JSON serialization parity if a session is ever marshalled)
+	// see the same shape.
+	session := &UserSession{
+		Subject:         userInfo.Name,
+		Email:           NormalizeEmail(userInfo.Email),
+		Name:            userInfo.DisplayName,
+		Provider:        PortalJWTIssuer,
+		Groups:          userInfo.LastSeenGroups,
+		PlatformRole:    userInfo.PlatformRole,
+		IsPlatformAdmin: userInfo.IsPlatformAdmin || userInfo.PlatformRole == RoleAdmin,
+	}
+	return session, nil
+}
+
+// jtiReplayCache stores recently-seen jti values until their natural exp.
+// Bounded by the portal proof's 60-second TTL: in steady state the cache
+// holds at most one proof per concurrent request in any 60-second window.
+// Lazy sweep runs at most once per sweepInterval to reclaim expired entries
+// without paying the cost on every request.
+//
+// Restart semantics: a process restart drops the cache. A proof from before
+// the restart whose exp has not yet passed (worst case, 60 seconds) can be
+// replayed once after restart. This is acceptable per the staged plan
+// (Stage 1 trades a 60-second post-restart replay window against the cost
+// of a persistent store; persistence is reconsidered if Stage 4 measurement
+// shows replay-after-restart is a real concern).
+type jtiReplayCache struct {
+	mu        sync.Mutex
+	seen      map[string]time.Time
+	sweepIv   time.Duration
+	lastSweep time.Time
+	now       func() time.Time
+}
+
+func newJTIReplayCache(sweepInterval time.Duration) *jtiReplayCache {
+	return &jtiReplayCache{
+		seen:      make(map[string]time.Time),
+		sweepIv:   sweepInterval,
+		lastSweep: time.Now(),
+		now:       time.Now,
+	}
+}
+
+// checkAndStore records a new jti. Returns false if the jti was already
+// recorded AND its prior recorded exp has not yet passed (a replay attempt);
+// returns true if the jti is new or its prior recording had expired naturally.
+func (c *jtiReplayCache) checkAndStore(jti string, exp time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.now()
+	if priorExp, ok := c.seen[jti]; ok && now.Before(priorExp) {
+		return false
+	}
+	c.seen[jti] = exp
+	if now.Sub(c.lastSweep) >= c.sweepIv {
+		for k, e := range c.seen {
+			if now.After(e) {
+				delete(c.seen, k)
+			}
+		}
+		c.lastSweep = now
+	}
+	return true
+}

--- a/internal/auth/portal_jwt.go
+++ b/internal/auth/portal_jwt.go
@@ -48,6 +48,10 @@ type PortalUserResolver interface {
 	GetUserByEmail(ctx context.Context, email string) (*UserInfo, error)
 }
 
+// Compile-time assertion that *PortalJWTVerifier satisfies the
+// PortalProofVerifier interface SessionMiddleware depends on.
+var _ PortalProofVerifier = (*PortalJWTVerifier)(nil)
+
 // PortalJWTVerifier verifies portal-issued Ed25519 JWTs and resolves them
 // to a per-request UserSession backed by the User CRD.
 //
@@ -131,8 +135,7 @@ func ParsePortalPublicKeysPEM(pemData string) (map[string]ed25519.PublicKey, err
 
 // fingerprintKid derives a short stable kid from the public key bytes when
 // no kid header is supplied in the PEM block. Hex-encoded first 8 bytes of
-// the raw public key; collision-resistant enough for at most a few rotation
-// generations.
+// the raw public key.
 func fingerprintKid(pk ed25519.PublicKey) string {
 	const hex = "0123456789abcdef"
 	out := make([]byte, 16)

--- a/internal/auth/portal_jwt_test.go
+++ b/internal/auth/portal_jwt_test.go
@@ -1,0 +1,429 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// fakeUserResolver returns prepared UserInfo values keyed by email.
+// It avoids standing up the K8s dynamic client for verifier-level tests.
+type fakeUserResolver struct {
+	byEmail map[string]*UserInfo
+	err     error
+}
+
+func (f *fakeUserResolver) GetUserByEmail(_ context.Context, email string) (*UserInfo, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	u, ok := f.byEmail[strings.ToLower(strings.TrimSpace(email))]
+	if !ok {
+		return nil, ErrUserNotFound
+	}
+	return u, nil
+}
+
+// testKeyPair returns a fresh Ed25519 keypair and an associated kid for tests.
+func testKeyPair(t *testing.T) (string, ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return "test-kid", pub, priv
+}
+
+// signProof builds a portal proof with the given claims and returns the
+// signed JWT string. Defaults give a valid 60-second window starting now.
+func signProof(t *testing.T, priv ed25519.PrivateKey, kid string, mut func(*jwt.RegisteredClaims, *jwt.Token)) string {
+	t.Helper()
+	now := time.Now()
+	claims := jwt.RegisteredClaims{
+		Issuer:    PortalJWTIssuer,
+		Audience:  jwt.ClaimStrings{PortalJWTAudience},
+		Subject:   "user@example.com",
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(30 * time.Second)),
+		NotBefore: jwt.NewNumericDate(now.Add(-1 * time.Second)),
+		ID:        "jti-" + t.Name(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, &claims)
+	token.Header["kid"] = kid
+	if mut != nil {
+		mut(&claims, token)
+	}
+	signed, err := token.SignedString(priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signed
+}
+
+func newVerifierWithFakeUser(t *testing.T, pub ed25519.PublicKey, kid string, user *UserInfo) *PortalJWTVerifier {
+	t.Helper()
+	users := &fakeUserResolver{byEmail: map[string]*UserInfo{strings.ToLower(user.Email): user}}
+	v, err := NewPortalJWTVerifier(map[string]ed25519.PublicKey{kid: pub}, users)
+	if err != nil {
+		t.Fatalf("verifier: %v", err)
+	}
+	return v
+}
+
+func TestPortalVerifier_ValidProof_AuthsAsSub(t *testing.T) {
+	kid, pub, priv := testKeyPair(t)
+	user := &UserInfo{
+		Name:         "user",
+		Email:        "user@example.com",
+		DisplayName:  "User",
+		PlatformRole: RoleAdmin,
+	}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	proof := signProof(t, priv, kid, nil)
+	session, claimed, err := v.MaybeVerify(context.Background(), proof)
+	if err != nil {
+		t.Fatalf("MaybeVerify err: %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected claimed=true for portal proof")
+	}
+	if session == nil {
+		t.Fatal("expected session, got nil")
+	}
+	if session.Email != "user@example.com" {
+		t.Errorf("Email=%q want %q", session.Email, "user@example.com")
+	}
+	if session.PlatformRole != RoleAdmin {
+		t.Errorf("PlatformRole=%q want %q", session.PlatformRole, RoleAdmin)
+	}
+	if !session.IsPlatformAdmin {
+		t.Error("IsPlatformAdmin should be true for admin PlatformRole")
+	}
+	if session.Provider != PortalJWTIssuer {
+		t.Errorf("Provider=%q want %q", session.Provider, PortalJWTIssuer)
+	}
+}
+
+func TestPortalVerifier_BadSignature_Rejects(t *testing.T) {
+	kid, pub, priv := testKeyPair(t)
+	user := &UserInfo{Name: "u", Email: "user@example.com", PlatformRole: RoleAdmin}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	proof := signProof(t, priv, kid, nil)
+	// Tamper the signature by flipping the last byte of the third segment.
+	parts := strings.Split(proof, ".")
+	if len(parts) != 3 {
+		t.Fatalf("unexpected JWT shape: %d parts", len(parts))
+	}
+	// Mutate one base64 char in the signature.
+	last := parts[2]
+	if len(last) == 0 {
+		t.Fatal("empty signature")
+	}
+	swap := byte('A')
+	if last[0] == swap {
+		swap = 'B'
+	}
+	parts[2] = string(swap) + last[1:]
+	tampered := strings.Join(parts, ".")
+
+	_, claimed, err := v.MaybeVerify(context.Background(), tampered)
+	if !claimed {
+		t.Fatal("expected claimed=true; tampered proof still asserts portal iss")
+	}
+	if err == nil {
+		t.Fatal("expected verification error")
+	}
+}
+
+func TestPortalVerifier_Expired_Rejects(t *testing.T) {
+	kid, pub, priv := testKeyPair(t)
+	user := &UserInfo{Name: "u", Email: "user@example.com", PlatformRole: RoleAdmin}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	proof := signProof(t, priv, kid, func(c *jwt.RegisteredClaims, _ *jwt.Token) {
+		past := time.Now().Add(-2 * time.Minute)
+		c.IssuedAt = jwt.NewNumericDate(past)
+		c.NotBefore = jwt.NewNumericDate(past)
+		c.ExpiresAt = jwt.NewNumericDate(past.Add(30 * time.Second))
+	})
+
+	_, claimed, err := v.MaybeVerify(context.Background(), proof)
+	if !claimed {
+		t.Fatal("expected claimed=true")
+	}
+	if err == nil {
+		t.Fatal("expected expired error")
+	}
+}
+
+func TestPortalVerifier_TTLOverMax_Rejects(t *testing.T) {
+	kid, pub, priv := testKeyPair(t)
+	user := &UserInfo{Name: "u", Email: "user@example.com", PlatformRole: RoleAdmin}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	proof := signProof(t, priv, kid, func(c *jwt.RegisteredClaims, _ *jwt.Token) {
+		now := time.Now()
+		c.IssuedAt = jwt.NewNumericDate(now)
+		c.ExpiresAt = jwt.NewNumericDate(now.Add(10 * time.Minute))
+	})
+
+	_, claimed, err := v.MaybeVerify(context.Background(), proof)
+	if !claimed {
+		t.Fatal("expected claimed=true")
+	}
+	if err == nil || !strings.Contains(err.Error(), "TTL") {
+		t.Fatalf("expected TTL violation, got %v", err)
+	}
+}
+
+func TestPortalVerifier_WrongAudience_Rejects(t *testing.T) {
+	kid, pub, priv := testKeyPair(t)
+	user := &UserInfo{Name: "u", Email: "user@example.com", PlatformRole: RoleAdmin}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	proof := signProof(t, priv, kid, func(c *jwt.RegisteredClaims, _ *jwt.Token) {
+		c.Audience = jwt.ClaimStrings{"some-other-service"}
+	})
+
+	_, claimed, err := v.MaybeVerify(context.Background(), proof)
+	if !claimed {
+		t.Fatal("expected claimed=true")
+	}
+	if err == nil {
+		t.Fatal("expected audience error")
+	}
+}
+
+func TestPortalVerifier_ReplayedJTI_Rejects(t *testing.T) {
+	kid, pub, priv := testKeyPair(t)
+	user := &UserInfo{Name: "u", Email: "user@example.com", PlatformRole: RoleAdmin}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	proof := signProof(t, priv, kid, nil)
+
+	_, claimed, err := v.MaybeVerify(context.Background(), proof)
+	if !claimed || err != nil {
+		t.Fatalf("first verify must succeed: claimed=%v err=%v", claimed, err)
+	}
+	_, claimed, err = v.MaybeVerify(context.Background(), proof)
+	if !claimed {
+		t.Fatal("expected claimed=true on replay attempt")
+	}
+	if err == nil || !strings.Contains(err.Error(), "replayed") {
+		t.Fatalf("expected replay error, got %v", err)
+	}
+}
+
+func TestPortalVerifier_UnknownSub_Rejects(t *testing.T) {
+	kid, pub, priv := testKeyPair(t)
+	// Resolver does NOT contain the proof's sub.
+	users := &fakeUserResolver{byEmail: map[string]*UserInfo{}}
+	v, _ := NewPortalJWTVerifier(map[string]ed25519.PublicKey{kid: pub}, users)
+
+	proof := signProof(t, priv, kid, nil)
+	_, claimed, err := v.MaybeVerify(context.Background(), proof)
+	if !claimed {
+		t.Fatal("expected claimed=true")
+	}
+	if err == nil || !errors.Is(err, ErrUserNotFound) && !strings.Contains(err.Error(), "user not found") {
+		t.Fatalf("expected user-not-found, got %v", err)
+	}
+}
+
+func TestPortalVerifier_DisabledUser_Rejects(t *testing.T) {
+	kid, pub, priv := testKeyPair(t)
+	user := &UserInfo{
+		Name:         "u",
+		Email:        "user@example.com",
+		PlatformRole: RoleAdmin,
+		Disabled:     true,
+	}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	proof := signProof(t, priv, kid, nil)
+	_, claimed, err := v.MaybeVerify(context.Background(), proof)
+	if !claimed {
+		t.Fatal("expected claimed=true")
+	}
+	if !errors.Is(err, ErrUserDisabled) {
+		t.Fatalf("expected ErrUserDisabled, got %v", err)
+	}
+}
+
+func TestPortalVerifier_NonPortalIssuer_FallsThrough(t *testing.T) {
+	// Load-bearing console-safety test: a JWT with iss != PortalJWTIssuer
+	// must NOT be claimed by the portal verifier. The middleware-level
+	// counterpart of this test in middleware_test.go exercises the same
+	// invariant against the full middleware flow.
+	kid, pub, priv := testKeyPair(t)
+	user := &UserInfo{Name: "u", Email: "user@example.com", PlatformRole: RoleAdmin}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	// Build a JWT with iss="butler-server" (the console session shape).
+	now := time.Now()
+	claims := jwt.RegisteredClaims{
+		Issuer:    "butler-server",
+		Audience:  jwt.ClaimStrings{PortalJWTAudience},
+		Subject:   "user@example.com",
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(30 * time.Second)),
+		ID:        "jti-not-portal",
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodEdDSA, &claims)
+	tok.Header["kid"] = kid
+	signed, err := tok.SignedString(priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	session, claimed, err := v.MaybeVerify(context.Background(), signed)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if claimed {
+		t.Fatal("portal verifier must NOT claim a non-portal iss")
+	}
+	if session != nil {
+		t.Fatal("expected nil session on fall-through")
+	}
+}
+
+func TestPortalVerifier_MalformedToken_FallsThrough(t *testing.T) {
+	kid, pub, _ := testKeyPair(t)
+	user := &UserInfo{Name: "u", Email: "user@example.com", PlatformRole: RoleAdmin}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	// Arbitrary non-JWT bytes (e.g. an HMAC-issued cookie value from butler-
+	// server's SessionService that an attacker mistakenly passes as Bearer).
+	_, claimed, err := v.MaybeVerify(context.Background(), "not-a-jwt-at-all")
+	if err != nil {
+		t.Fatalf("unexpected err on malformed: %v", err)
+	}
+	if claimed {
+		t.Fatal("malformed token must not be claimed")
+	}
+}
+
+func TestPortalVerifier_UnknownKID_Rejects(t *testing.T) {
+	kid, pub, _ := testKeyPair(t)
+	user := &UserInfo{Name: "u", Email: "user@example.com", PlatformRole: RoleAdmin}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	// Sign with a fresh private key whose pub the verifier doesn't know,
+	// and label the kid the verifier doesn't have either.
+	_, _, otherPriv := testKeyPair(t)
+	proof := signProof(t, otherPriv, "unknown-kid", nil)
+
+	_, claimed, err := v.MaybeVerify(context.Background(), proof)
+	if !claimed {
+		t.Fatal("expected claimed=true; portal iss is set")
+	}
+	if err == nil || !strings.Contains(err.Error(), "kid") {
+		t.Fatalf("expected kid error, got %v", err)
+	}
+}
+
+func TestPortalVerifier_HMACTokenWithPortalIss_ClaimedThenRejected(t *testing.T) {
+	// A token whose iss claim is PortalJWTIssuer is claimed by the
+	// portal verifier (iss-routing succeeds) even if its algorithm is
+	// HMAC. Verification then fails because the verifier enforces
+	// EdDSA-only and the algorithm check rejects the token. This is
+	// the correct behavior: callers MUST reject the request rather
+	// than fall through, since the token claimed to be a portal
+	// proof and the verifier owns the failure.
+	kid, pub, _ := testKeyPair(t)
+	user := &UserInfo{Name: "u", Email: "user@example.com", PlatformRole: RoleAdmin}
+	v := newVerifierWithFakeUser(t, pub, kid, user)
+
+	now := time.Now()
+	claims := jwt.RegisteredClaims{
+		Issuer:    PortalJWTIssuer,
+		Audience:  jwt.ClaimStrings{PortalJWTAudience},
+		Subject:   "user@example.com",
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(30 * time.Second)),
+		ID:        "jti-hmac",
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, &claims)
+	tok.Header["kid"] = kid
+	signed, _ := tok.SignedString([]byte("not-an-ed25519-key"))
+
+	_, claimed, err := v.MaybeVerify(context.Background(), signed)
+	if !claimed {
+		t.Fatal("expected claimed=true; iss=PortalJWTIssuer must be routed to the portal path")
+	}
+	if err == nil {
+		t.Fatal("expected verification error; HMAC algorithm must be rejected")
+	}
+}
+
+func TestParsePortalPublicKeysPEM_SingleKey(t *testing.T) {
+	_, pub, _ := testKeyPair(t)
+	pkix, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:    "PUBLIC KEY",
+		Headers: map[string]string{"kid": "key-1"},
+		Bytes:   pkix,
+	})
+
+	keys, err := ParsePortalPublicKeysPEM(string(pemBytes))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got, want := len(keys), 1; got != want {
+		t.Fatalf("keys=%d want %d", got, want)
+	}
+	if _, ok := keys["key-1"]; !ok {
+		t.Errorf("missing kid=key-1: %#v", keys)
+	}
+}
+
+func TestParsePortalPublicKeysPEM_NoKidFingerprintFallback(t *testing.T) {
+	_, pub, _ := testKeyPair(t)
+	pkix, _ := x509.MarshalPKIXPublicKey(pub)
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pkix,
+	})
+	keys, err := ParsePortalPublicKeysPEM(string(pemBytes))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("keys=%d want 1", len(keys))
+	}
+	for kid := range keys {
+		if len(kid) != 16 {
+			t.Errorf("fingerprint kid wrong length: %q", kid)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,20 @@ type AuthConfig struct {
 	// Legacy basic auth (deprecated, will be removed)
 	AdminUsername string
 	AdminPassword string
+
+	// PortalPubKey is the PEM-encoded Ed25519 public key(s) used to verify
+	// portal-issued identity proofs. Empty disables the portal-proof path.
+	// Stage 1 default: empty (path dormant). Stage 2 onward sets this in
+	// production so the portal's signed proofs are accepted by SessionMiddleware.
+	// Multiple keys (kid-indexed) may be concatenated for rotation; see
+	// auth.ParsePortalPublicKeysPEM.
+	PortalPubKey string
+
+	// AllowHeaderImpersonation gates the legacy X-Butler-User-Email override
+	// inside the platform-admin branch of SessionMiddleware. true preserves
+	// pre-Stage-1 behavior (the portal proxy's current carrier). Stage 4
+	// flips this to false ahead of the cleanup PR that deletes the block.
+	AllowHeaderImpersonation bool
 }
 
 // OIDCConfig holds OIDC provider configuration.
@@ -152,8 +166,10 @@ func Load() *Config {
 			SessionExpiry: getDurationEnv("BUTLER_SESSION_EXPIRY", 24*time.Hour),
 			SecureCookies: getBoolEnv("BUTLER_SECURE_COOKIES", false),
 			// Legacy - deprecated
-			AdminUsername: getEnv("BUTLER_ADMIN_USERNAME", "admin"),
-			AdminPassword: getEnv("BUTLER_ADMIN_PASSWORD", ""),
+			AdminUsername:            getEnv("BUTLER_ADMIN_USERNAME", "admin"),
+			AdminPassword:            getEnv("BUTLER_ADMIN_PASSWORD", ""),
+			PortalPubKey:             getEnv("BUTLER_PORTAL_PUBKEY", ""),
+			AllowHeaderImpersonation: getBoolEnv("BUTLER_ALLOW_HEADER_IMPERSONATION", true),
 		},
 		OIDC: OIDCConfig{
 			Enabled:                  getBoolEnv("BUTLER_OIDC_ENABLED", false),
@@ -173,7 +189,7 @@ func Load() *Config {
 			RefreshExpiry:    getDurationEnv("BUTLER_CLI_REFRESH_EXPIRY", 7*24*time.Hour),
 			SACleanupTTL:     getDurationEnv("BUTLER_CLI_SA_TTL", 30*24*time.Hour),
 			DeviceCodeExpiry: getDurationEnv("BUTLER_CLI_DEVICE_CODE_EXPIRY", 15*time.Minute),
-			ExternalAPIURL:  getEnv("BUTLER_CLI_EXTERNAL_API_URL", ""),
+			ExternalAPIURL:   getEnv("BUTLER_CLI_EXTERNAL_API_URL", ""),
 		},
 		TenantNamespace: getEnv("BUTLER_TENANT_NAMESPACE", "butler-tenants"),
 		SystemNamespace: getEnv("BUTLER_SYSTEM_NAMESPACE", "butler-system"),


### PR DESCRIPTION
Stage 1 of the P0 #3 fix for `X-Butler-User-Email` header-identity impersonation. Purely additive: adds a verification capability + a boundary-enforced invariant + a back-compat flag. **Changes nothing observable for any caller under the default configuration.** The cutover to require signed proofs is Stage 4.

## What this PR adds

- **`internal/auth/portal_jwt.go`**: new `PortalJWTVerifier` that validates Ed25519-signed portal proofs. Verifies signature (kid-indexed public key), `iss == "butler-portal"`, `aud == "butler-server"`, `exp` within 60 seconds of `iat` (+ 5s slop for portal/server clock skew on the TTL cap; the actual `exp` check is strict), `nbf`, `jti` anti-replay (in-memory cache, lazy sweep, bounded by the 60s TTL), and resolves `sub` against the User CRD via `UserService.GetUserByEmail`. Constructs a per-request `UserSession` with `PlatformRole` derived from the CRD spec. Compile-time assertion `var _ PortalProofVerifier = (*PortalJWTVerifier)(nil)` locks the interface satisfaction.

- **`internal/auth/middleware.go`**:
  - New `PortalProofVerifier` interface (1 method: `MaybeVerify`). The interface seam makes the claimed-is-terminal invariant testable at the middleware boundary with an injected stub.
  - New branch in `SessionMiddleware` BEFORE `SessionService.ValidateSession`. The branch routes tokens whose `iss` claim is `butler-portal` to `PortalVerifier.MaybeVerify`. Tokens with any other `iss` (console session JWTs from `SessionService.CreateSession` which sets `iss=butler-server`, CLI device-flow sessions, etc.) fall through to `ValidateSession` UNCHANGED.
  - **Claimed-is-terminal boundary guard**: when `MaybeVerify` reports `claimed=true`, the middleware verifies the returned session is non-nil before proceeding. A `(nil, true, nil)` shape (which would be a verifier-internals refactor mistake) is intercepted at the boundary and returns 401 instead of falling through to `ValidateSession`. The current `verifyClaimed` honors the invariant by construction on every return path; the guard backstops the invariant so a future refactor cannot open the bypass path silently.
  - Legacy `X-Butler-User-Email` impersonation sub-block at lines ~96-114 wrapped in `if cfg.AllowHeaderImpersonation { ... }`.

- **`internal/config/config.go`**: two new env vars on `AuthConfig`:
  - `BUTLER_PORTAL_PUBKEY` (default empty): PEM-encoded Ed25519 public key(s). When unset, no `PortalJWTVerifier` is constructed and the new branch is dormant.
  - `BUTLER_ALLOW_HEADER_IMPERSONATION` (default `true`): preserves the current header-impersonation behavior in the platform-admin branch.

- **`internal/api/router.go`**: constructs `PortalJWTVerifier` only when the pubkey is set; wires both new fields into `SessionMiddlewareConfig`.

## Load-bearing invariants (mutation-proven, all three)

1. **Zero observable change under defaults** (`BUTLER_PORTAL_PUBKEY` unset, `BUTLER_ALLOW_HEADER_IMPERSONATION=true`). Console, portal, and CLI traffic byte-identical to pre-Stage-1.
2. **Iss-routing console-safety**. Tokens with `iss != "butler-portal"` (which includes every console / CLI / legacy admin token) fall through to `ValidateSession` UNCHANGED, even when the portal verifier is configured. Mutation: break the iss gate to always-claim; the console-fallthrough test fails with `401 invalid portal proof`.
3. **Claimed-is-terminal at the boundary**. When `MaybeVerify` reports `claimed=true`, the middleware EITHER produces a verified session OR returns 401; it never falls through. Mutation: remove the new guard; the test fails because the body becomes `invalid session` (from `ValidateSession`'s fall-through rejection of the Ed25519-signed token) instead of `invalid portal proof`.

## Tests

`internal/auth/portal_jwt_test.go` (14 tests): valid proof authenticates as `sub`; bad signature rejected; expired rejected; TTL over 60s+5s slop rejected; wrong audience rejected; replayed `jti` rejected; unknown `sub` rejected; disabled user rejected; non-portal `iss` falls through (`claimed=false`, no error); malformed token falls through; unknown `kid` rejected; HMAC token with portal `iss` claimed then rejected (algorithm enforcement); PEM parsing single key with explicit `kid`; PEM parsing falls back to fingerprint when no `kid` header.

`internal/auth/middleware_test.go` (7 new tests): no portal verifier + console-style HS256 JWT passes through; **console-safety mutation-proven** (portal verifier configured + console `iss=butler-server` JWT falls through to `ValidateSession`); valid portal Ed25519 proof authenticates as `sub`; tampered portal proof returns 401; `AllowHeaderImpersonation=true` + admin + `X-Butler-User-Email` overrides (back-compat preserved); **`AllowHeaderImpersonation=false` mutation-proven** (override skipped); **claimed-is-terminal mutation-proven** (stub verifier returning `(nil, true, nil)` triggers the new boundary guard, returns `401 invalid portal proof`; mutation removes the guard and the body assertion fails).

## Mutation results recorded for the 3-pass review

| Mutation | Change | Tests that fail |
|---|---|---|
| Iss gate to always-claim | `if claims.Issuer != PortalJWTIssuer` -> `if false && claims.Issuer != PortalJWTIssuer` | `TestPortalVerifier_NonPortalIssuer_FallsThrough` + `TestSessionMiddleware_PortalVerifier_NonPortalIssJWTFallsThrough` |
| Flag-guard removed | `if cfg.AllowHeaderImpersonation` -> `if true` | `TestSessionMiddleware_AllowHeaderImpersonationFalse_HeaderIgnored` |
| **Claimed-is-terminal guard removed** | **`if portalSess == nil { 401; return }` -> `if false { ... }`** | **`TestSessionMiddleware_ClaimedWithNilSession_RejectsTerminal` (body asserts `invalid portal proof`; mutation makes body `invalid session` from fall-through)** |

All three load-bearing tests are mutation-proven non-vacuous.

## Severity context on the claimed-is-terminal guard

Current code WAS terminal by construction: `verifyClaimed` honors the invariant on every return path I traced (every error path returns `nil, <non-nil err>`; the single success path returns `<non-nil session>, nil`). Even under a hypothetical future refactor that introduced `return nil, nil`, the fall-through to `ValidateSession` would be backstopped twice: (1) `ValidateSession` enforces HMAC-only signing and would reject the Ed25519 portal proof, (2) an attacker would still need `BUTLER_JWT_SECRET` to mint a valid HMAC session. So this is a defense-in-depth gap at the middleware boundary, not a live bypass.

The boundary guard makes the invariant **enforced-in-code** rather than **implied-by-construction**. At an auth boundary, an implicit cross-component invariant is invisible to a careless refactor; a guard + test fails the build. ~50 LOC to remove that fragility is the correct trade.

## What this PR explicitly does NOT do

- Does not flip the back-compat flag. `BUTLER_ALLOW_HEADER_IMPERSONATION` default stays `true`. Stage 4 is a later config flip + cleanup PR.
- Does not deploy portal-issued proofs. butler-portal continues to use the legacy admin session + `X-Butler-User-Email` carrier. Stage 2 is the portal-side carrier swap.
- Does not change console / CLI / direct-API behavior. Verified via the mutation-proven iss-routing test.
- Does not add a JWKS endpoint or key rotation tooling. Single-key env-var configuration only; rotation is supported by the data model (`map[kid]ed25519.PublicKey`) but operational hot-reload tooling lands when first needed.
- Does not touch the existing detector / OIDC / login flows. The portal-JWT branch sits BEFORE `ValidateSession` and does NOT go through any login handler.

## Verification

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./...` clean across all packages (auth, handlers, certificates, gitops, httpx, k8s, websocket).
- `gofmt -d` clean on every touched file.

## References

- Audit P0 #3 detail and test evidence: `butler-portal` branch `portal-console-gap-audit-2026-05-revised` at `.secrets/portal-console-gap-2026-05-revised.md` Section 6.
- Stage plan: `~/.butler/rescue/portal-p0-3-option-b-plan-2026-06-09.md` Sections 4-6.
- Console-impact confirmation: same plan doc, Appendix.