### PR TITLE
feat(auth): log portal proof verification success at Info

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -134,6 +134,16 @@ func SessionMiddleware(cfg SessionMiddlewareConfig) func(http.Handler) http.Hand
 						http.Error(w, `{"error":"invalid portal proof"}`, http.StatusUnauthorized)
 						return
 					}
+					if cfg.Logger != nil {
+						// Symmetric with the rejected/invariant-fail Warn lines
+						// above. Without this success line, the proof path is
+						// silent at every level and operators cannot confirm
+						// that portal-mediated traffic is taking the proof
+						// branch in production. That confirmation is needed
+						// before Stage 4 removes the legacy header-trust
+						// fallback.
+						cfg.Logger.Info("Portal proof verified", "sub", portalSess.Email)
+					}
 					user = portalSess
 				}
 			}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -330,6 +332,61 @@ func TestSessionMiddleware_PortalProofValid_AuthsAsSub(t *testing.T) {
 	}
 	if got := rec.Body.String(); got != portalEmail {
 		t.Errorf("downstream saw email=%q want %q", got, portalEmail)
+	}
+}
+
+func TestSessionMiddleware_PortalProofValid_LogsSuccessAtInfo(t *testing.T) {
+	// Operators need a positive log signal that the proof path is winning in
+	// production, especially before Stage 4 removes the legacy header-trust
+	// fallback. The rejected path already logs at Warn; the success path
+	// should log at Info so the trail is symmetric and visible without
+	// raising the global log level.
+	const portalEmail = "portal-user@example.com"
+	kid, pub, priv := testKeyPair(t)
+	users := &fakeUserResolver{
+		byEmail: map[string]*UserInfo{
+			portalEmail: {
+				Name:         "portal-user",
+				Email:        portalEmail,
+				DisplayName:  "Portal User",
+				PlatformRole: RoleAdmin,
+			},
+		},
+	}
+	verifier, _ := NewPortalJWTVerifier(map[string]ed25519.PublicKey{kid: pub}, users)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	cfg := SessionMiddlewareConfig{
+		SessionService:           NewSessionService("unused", time.Hour),
+		PortalVerifier:           verifier,
+		AllowHeaderImpersonation: true,
+		Logger:                   logger,
+	}
+
+	proof := signProof(t, priv, kid, func(c *jwt.RegisteredClaims, _ *jwt.Token) {
+		c.Subject = portalEmail
+		c.ID = "jti-portal-mw-log"
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)
+	req.Header.Set("Authorization", "Bearer "+proof)
+	rec := runMiddleware(t, cfg, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q want 200", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(buf.String(), `"msg":"Portal proof verified"`) {
+		t.Errorf("expected Info log %q in middleware output, got: %s", "Portal proof verified", buf.String())
+	}
+	if !strings.Contains(buf.String(), `"sub":"`+portalEmail+`"`) {
+		t.Errorf("expected sub=%q in success log, got: %s", portalEmail, buf.String())
+	}
+	if !strings.Contains(buf.String(), `"level":"INFO"`) {
+		t.Errorf("expected level=INFO on success log, got: %s", buf.String())
+	}
+	if strings.Contains(buf.String(), `"msg":"Portal proof rejected"`) {
+		t.Errorf("success path must not emit the rejected log, got: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

``SessionMiddleware``'s portal-proof branch was silent on success: rejected proofs emit a Warn log (``Portal proof rejected``), but verified proofs left no log trail at any level. Operators had no positive observability that the proof path was actually winning real user traffic in production.

That observation matters now: Stage 3 of the P0 #3 impersonation fix is live (portal mints proofs, server's PortalVerifier is loaded). Before Stage 4 removes the legacy header-trust fallback (``BUTLER_ALLOW_HEADER_IMPERSONATION=false``), we need a positive log signal that the proof path is winning real traffic, not just that the machinery is loaded.

Adds a symmetric ``Portal proof verified`` Info line with the resolved sub email next to the existing rejected/invariant-fail Warn lines.

## Diff

- ``middleware.go``: 9-line addition (Info log on the success branch of the portal-claimed flow).
- ``middleware_test.go``: new ``TestSessionMiddleware_PortalProofValid_LogsSuccessAtInfo`` covering the Info log fires with the right sub on a valid proof and the rejected log stays absent.

## Verification

- ``go test ./internal/auth/`` clean.
- New test ``PortalProofValid_LogsSuccessAtInfo`` PASS.
- Existing ``PortalProofValid_AuthsAsSub`` still PASS (no regression on the auth resolution).

## Test plan

- [x] ``go test ./internal/auth/``
- [x] ``go vet ./internal/auth/``
- [x] ``go build ./...``
- [ ] CI: build + image
- [ ] Post-release: butler-server v0.21.1 image rolls via Flux on butler-mgmt-live; observe the Info line appears in production logs on real Stage 3 user traffic; confirms the proof path is winning before Stage 4.